### PR TITLE
Handle case where input is a TranscodingStream.

### DIFF
--- a/src/fasta/reader.jl
+++ b/src/fasta/reader.jl
@@ -23,8 +23,10 @@ function Reader(input::IO; index = nothing)
     end
     if !(input isa TranscodingStream)
         stream = TranscodingStreams.NoopStream(input)
+        return Reader(State(stream, 1, 1, false), index)
+    else
+        return Reader(State(input, 1, 1, false), index)
     end
-    return Reader(State(stream, 1, 1, false), index)
 end
 
 function Base.eltype(::Type{<:Reader})

--- a/src/fastq/reader.jl
+++ b/src/fastq/reader.jl
@@ -23,8 +23,10 @@ function Reader(input::IO; fill_ambiguous = nothing)
     end
     if !(input isa TranscodingStream)
         stream = TranscodingStreams.NoopStream(input)
+        return Reader(State(stream, 1, 1, false), seq_transform)
+    else
+        return Reader(State(input, 1, 1, false), seq_transform)
     end
-    return Reader(State(stream, 1, 1, false), seq_transform)
 end
 
 function Base.eltype(::Type{<:Reader})


### PR DESCRIPTION
Trying to fix https://github.com/BioJulia/FASTX.jl/issues/8

Not sure this fixes all, but it seems at least to make me able to read fastq records through a `NoopStream` as follows:

```
julia> open(NoopStream, fq_filename) do stream
           reader = FASTQ.Reader(stream)
           record = FASTQ.Record()
           while !eof(reader)
               read!(reader, record)
               println(record)
           end
       end
```