### PR TITLE
add FASTA.identifier(record) example in docs

### DIFF
--- a/docs/src/manual/fasta.md
+++ b/docs/src/manual/fasta.md
@@ -52,6 +52,8 @@ Usually sequence records will be read sequentially from a file by iteration.
 reader = open(FASTA.Reader, "my-seqs.fasta")
 for record in reader
     ## Do something
+    # like showing the identifiers
+    @show FASTA.identifier(record)
 end
 close(reader)
 ```


### PR DESCRIPTION
To save 30mins of pain because new Julia users are still learning the syntax.
