### PR TITLE
Add docs on reading gzipped files

### DIFF
--- a/docs/src/manual/fasta.md
+++ b/docs/src/manual/fasta.md
@@ -58,6 +58,17 @@ end
 close(reader)
 ```
 
+Gzip compressed files can be streamed to the `Reader`
+using the [CodecZlib.jl](https://github.com/JuliaIO/CodecZlib.jl) package.
+
+```jlcon
+reader = FASTA.Reader(GzipDecompressorStream(open("my-reads.fasta.gz")))
+for record in reader
+    ## do something
+end
+close(reader)
+```
+
 You can also overwrite records in a while loop to avoid excessive memory allocation.
 
 ```jlcon

--- a/docs/src/manual/fastq.md
+++ b/docs/src/manual/fastq.md
@@ -59,6 +59,17 @@ end
 close(reader)
 ```
 
+Gzip compressed files can be streamed to the `Reader`
+using the [CodecZlib.jl](https://github.com/JuliaIO/CodecZlib.jl) package.
+
+```jlcon
+reader = FASTQ.Reader(GzipDecompressorStream(open("my-reads.fastq.gz")))
+for record in reader
+    ## do something
+end
+close(reader)
+```
+
 You can also overwrite records in a while loop to avoid excessive memory allocation.
 
 ```jlcon
@@ -106,11 +117,10 @@ FASTQ records have a quality string which have platform dependent encodings.
 The FASTQ submodule has encoding and decoding support for the following
 quality encodings. These can be used with a [`FASTQ.quality`](@ref) method, to
 ensure the correct quality score values are extracted from your FASTQ quality
-strings. 
+strings.
 
 - [`FASTQ.SANGER_QUAL_ENCODING`](@ref)
 - [`FASTQ.SOLEXA_QUAL_ENCODING`](@ref)
 - [`FASTQ.ILLUMINA13_QUAL_ENCODING`](@ref)
 - [`FASTQ.ILLUMINA15_QUAL_ENCODING`](@ref)
 - [`FASTQ.ILLUMINA18_QUAL_ENCODING`](@ref)
-


### PR DESCRIPTION
Sequence files, especially fastq files, are often compressed. This adds some notes on how to read Gzip compressed files to FASTA and FASTQ.

Credit @js135005 [on discourse](https://discourse.julialang.org/t/streaming-gziped-file-to-fastq-reader-where-to-add-method/36266) for pointing me to `CodecZlib`. 