### PR TITLE
Remove use of internal `encode_copy!` [DO NOT MERGE]

### DIFF
--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -30,7 +30,7 @@ This function verifies and indexes fields for accessors.
 
 !!! warning
     Note that the ownership of `data` is transferred to a new record object.
-    Editing the input data will edit the record, and is not advised after 
+    Editing the input data will edit the record, and is not advised after
     construction of the record.
 """
 function Record(data::Vector{UInt8})
@@ -197,6 +197,11 @@ function hasdescription(record)
     return isfilled(record) && record.description != 1:0
 end
 
+function Base.copy!(dest::BioSequences.LongSequence, src::Record)
+    resize!(dest, seqlen(src) % UInt)
+    copyto!(dest, 1, src, 1, seqlen(src))
+end
+
 """
     Base.copyto!(dest::BioSequences.LongSequence, src::Record)
 
@@ -206,21 +211,21 @@ the sequence represented in the fastq record. The first n elements of `dest` are
 overwritten, the other elements are left untouched.
 """
 function Base.copyto!(dest::BioSequences.LongSequence, src::Record)
-    return copyto!(dest, 1, src, 1, length(src.sequence))
+    return copyto!(dest, 1, src, 1, seqlen(src))
 end
 
 """
     Base.copyto!(dest::BioSequences.LongSequence, doff, src::Record, soff, N)
 
 Copy an N long block of sequence data from the fastq record `src`, starting at
-position `soff`, to the `BioSequence` dest, starting at position `doff`. 
+position `soff`, to the `BioSequence` dest, starting at position `doff`.
 """
 function Base.copyto!(dest::BioSequences.LongSequence, doff, src::Record, soff, N)
     checkfilled(src)
     if !hassequence(src)
         missingerror(:sequence)
     end
-    return BioSequences.encode_copy!(dest, doff, src.data, src.sequence[soff], N)
+    return copyto!(dest, doff, src.data, src.sequence[soff], N)
 end
 
 """
@@ -281,7 +286,7 @@ function hassequence(record::Record)
 end
 
 "Get the length of the fastq record's sequence."
-@inline seqlen(record::Record) = length(record.sequence)
+@inline seqlen(record::Record) = last(record.sequence) - first(record.sequence) + 1
 
 """
     quality(record::Record, [offset::Integer=33, [part::UnitRange]])::Vector{UInt8}


### PR DESCRIPTION
FASTX used `BioSequences.encode_copy!` despite (presumably?) being an internal function. Here, I've replaced it with `copyto!`, implemented in BioSequences by a recent PR.

How do we do this without causing too much breakage? Should we wait until a new release of BioSequences have been made, then change the lower bound of FASTX's dependency to the new release?

I also added a `Base.copy!` method. This is useful when iterating over a FASTA file, mutating a single sequence.