### PR TITLE
Inbounds FASTQ parser

### DIFF
--- a/src/fastq/readrecord.jl
+++ b/src/fastq/readrecord.jl
@@ -110,7 +110,7 @@ end
 
 returncode = :(return cs, linenum, found)
 
-context = Automa.CodeGenContext(generator = :goto)
+context = Automa.CodeGenContext(generator = :goto, checkbounds=false, loopunroll=4)
 
 isinteractive() && @info "Generating FASTQ parsing code..."
 


### PR DESCRIPTION
We can improve the speed of parsing unzipped FASTQ files with about 60% if we disable the boundscheck.

* The FASTA parser has boundscheck disabled, too.
* The readrecord code does not manipulate the index to the data, so it should be safe
