### PR TITLE
Fix zero-length copy

### DIFF
--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -285,6 +285,9 @@ function Base.copyto!(dest::BioSequences.LongSequence, doff, src::Record, soff, 
     if !hassequence(src)
         missingerror(:sequence)
     end
+    
+    # This check is here to prevent boundserror when indexing src.sequence
+    iszero(N) && return dest
     return copyto!(dest, doff, src.data, src.sequence[soff], N)
 end
 


### PR DESCRIPTION
A small change to avoid a `BoundsError` when trying to copy a `FastaRecord` with length-zero sequence to a sequence.