### PR TITLE
Bugfix: Make trailing FASTQ line optional

### DIFF
--- a/src/fastq/readrecord.jl
+++ b/src/fastq/readrecord.jl
@@ -43,7 +43,7 @@ machine = (function ()
     record.actions[:enter] = [:mark]
     record.actions[:exit] = [:record]
     
-    fastq = re.rep(re.cat(record, newline))
+    fastq = re.rep(re.cat(record, newline)) * re.opt(record)
     
     Automa.compile(fastq)
 end)()


### PR DESCRIPTION
On current master, FASTQ files must end in a newline. That is unnecessary. This simple fix allows the trailing newline to be omitted.