### PR TITLE
Fix windows newline bug (issue 25)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -281,6 +281,14 @@ end
     +2 high quality
     IJN
     """
+    
+    # Test issue 25
+    lines = ["@A", "A", "+", "F", "@B", "CA", "+", "CF"]
+    io = reader = FASTQ.Reader(IOBuffer(join(lines, "\r\n") * "\r\n"))
+    record = FASTQ.Record()
+    read!(reader, record)
+    read!(reader, record)
+    @test eof(reader)    
 
     @testset "Record" begin
         record = FASTQ.Record()


### PR DESCRIPTION
This is a bugfix to issue #25 .

Briefly, the problem was that, in `readrecord.jl`, at the state transition after a record, `@escape` was called. On UNIX systems, this would occur at the `\n` byte after a record, which would put the machine in a state immediately before the next record, or at EOF if at last record. However, on Windows system where the newline is two bytes (`\r\n`), this would occur after only the `\r` byte had been consumed. This means that the machine would not be at EOF, even though all records had been consumed.