### PR TITLE
Add constant time fasta index seeking [NEED REVIEW]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Release](https://img.shields.io/github/release/BioJulia/FASTX.jl.svg)](https://github.com/BioJulia/FASTX.jl/releases/latest)
 [![MIT license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/BioJulia/FASTX.jl/blob/master/LICENSE) 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3663087.svg)](https://doi.org/10.5281/zenodo.3663087)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3361839.svg)](https://doi.org/10.5281/zenodo.3361839)
 [![Stable documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://biojulia.github.io/FASTX.jl/stable)
 [![Latest documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://biojulia.github.io/FASTX.jl/latest/)
 [![Pkg Status](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)

--- a/src/fasta/index.jl
+++ b/src/fasta/index.jl
@@ -8,6 +8,7 @@
 
 # http://www.htslib.org/doc/faidx.html
 struct Index
+    # offset for the record's sequence by header: See above specification
     names::Dict{String, Int}
     lengths::Vector{Int}
     offsets::Vector{Int}
@@ -50,6 +51,7 @@ function Base.getindex(index::Index, name::AbstractString)
 end
 
 # Set the reading position of `input` to the starting position of the record `name`.
+# TODO: Return the seek position to be consistent with Base?
 function seekrecord(input::IO, index::Index, name::AbstractString)
     i = index[name]
     if i == 1
@@ -62,6 +64,8 @@ function seekrecord(input::IO, index::Index, name::AbstractString)
         prev_linebase = index.linebases[i - 1]
         prev_linewidth = index.linewidths[i - 1]
 
+        # Note: newline_len may differ between sequences in the same file, as per
+        # the specification.
         newline_len = prev_linewidth - prev_linebase
         len = cld(prev_len, prev_linebase) * newline_len + prev_len
         offset = prev_offset + len

--- a/src/fasta/reader.jl
+++ b/src/fasta/reader.jl
@@ -71,6 +71,12 @@ function Base.getindex(reader::Reader, name::AbstractString)
     return record
 end
 
+"""
+    extract(reader::Reader, Alphabet, name::AbstractString, range::UnitRange)
+
+Extract a subsequence given by index `range` from the sequence `named` in a
+`Reader` with an index. Returns a `LongSequence` with the given `Alphabet`.   
+"""
 function extract(reader::Reader, A::BioSequences.Alphabet, name::AbstractString, range::UnitRange)
     index = reader.index
     if index == nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,10 +10,12 @@ import BioSequences:
     LongDNASeq,
     LongAminoAcidSeq,
     LongSequence,
+    AminoAcidAlphabet,
     DNAAlphabet,
     DNA_N,
     DNA_A,
-    DNA_G
+    DNA_G,
+    Alphabet
 
 @testset "FASTA" begin
     @testset "Record" begin
@@ -108,6 +110,7 @@ import BioSequences:
     @test FASTA.sequence(record) == aa"VLMALGMTDLFIPSANLTG*"
     @test copyto!(LongAminoAcidSeq(FASTA.seqlen(record)), record) == aa"VLMALGMTDLFIPSANLTG*"
     @test_throws ArgumentError copyto!(LongAminoAcidSeq(10), FASTA.Record())
+    @test_throws ArgumentError FASTA.extract(reader, AminoAcidAlphabet(), "seqA", 2:3)
 
     function test_fasta_parse(filename, valid)
         filepath = joinpath(path_of_format("FASTA"), filename)
@@ -202,6 +205,10 @@ import BioSequences:
                 AAATAGCCCTCATGTACGTCTCCTCCAAGCCCTGTTGTCTCTTACCCGGA
                 TGTTCAACCAAAAGCTACTTACTACCTTTATTTTATGTTTACTTTTTATA
                 """
+
+                seq = FASTA.extract(reader, DNAAlphabet{2}(), "chr2", 10:20)
+                @test seq == dna"TGCATGCATGC"
+                @test Alphabet(seq) == DNAAlphabet{2}()
 
                 chr2 = reader["chr2"]
                 @test FASTA.identifier(chr2) == "chr2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,12 +175,13 @@ import BioSequences:
     end
 
     @testset "Faidx" begin
+        # Need to make sure it can handle mixed Unix and Windows newlines
         fastastr = """
         >chr1
         CCACACCACACCCACACACC
         >chr2
-        ATGCATGCATGCAT
-        GCATGCATGCATGC
+        ATGCATGCATGCAT\r
+        GCATGCATGCATGC\r
         >chr3
         AAATAGCCCTCATGTACGTCTCCTCCAAGCCCTGTTGTCTCTTACCCGGA
         TGTTCAACCAAAAGCTACTTACTACCTTTATTTTATGTTTACTTTTTATA
@@ -190,9 +191,9 @@ import BioSequences:
         # generated with `samtools faidx`
         faistr = """
         chr1	20	6	20	21
-        chr2	28	33	14	15
-        chr3	100	69	50	51
-        chr4	5	177	5	6
+        chr2	28	33	14	16
+        chr3	100	71	50	51
+        chr4	5	179	5	6
         """
         mktempdir() do dir
             filepath = joinpath(dir, "test.fa")


### PR DESCRIPTION
Addresses issue #29. This PR also includes #30 .

Changes:
* `FASTA.Index` now uses a `Dict` instead of a vector of names. This is slower to construct and more memory inefficient, but obviously has the benefit of constant-time lookup in the index. I'd argue that if you create an index, you do so specifically in order to have fast lookup, and you probably don't care about the few extra kilobytes of RAM used, or miliseconds when constructing the index.
* Added a new method: `extract(r::Reader, A::Alphabet, s::AbstractString, u::UnitRange)`, which does the same as `sequence(A, r[s], u)`, but does not load the entire sequence into memory first.