### PR TITLE
Subset fastq record using string syntax

### DIFF
--- a/docs/src/manual/fastq.md
+++ b/docs/src/manual/fastq.md
@@ -124,3 +124,45 @@ strings.
 - [`FASTQ.ILLUMINA13_QUAL_ENCODING`](@ref)
 - [`FASTQ.ILLUMINA15_QUAL_ENCODING`](@ref)
 - [`FASTQ.ILLUMINA18_QUAL_ENCODING`](@ref)
+
+## FASTQ Reads
+
+The FASTQ Record data structure is very close to the FASTQ file-format, and stores all data in a data vector.
+The FASTQ Read data structure is better suited for sequence manipulations:
+
+- Identifier and description are Strings.
+- Sequence is stored as a `BioSequence` and not just as ASCII characters.
+- The quality is stored as raw PHRED-score (Integer), and there is no offset to worry about.
+
+A FASTQ Read record also allows for convenient sub-setting using normal range syntax as for Arrays and Strings:
+
+```jlcon
+using FASTX
+
+read = FASTQ.Read(first(FASTQ.Reader(open("my-reads.fastq", "r"))),33)
+# FASTX.FASTQ.FASTQRead{BioSequences.DNAAlphabet{4}}:
+#    identifier: SEQ_ID
+#   description: 
+#      sequence: GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
+#       quality: [0, 6, 6, 9, 7, 7, 7, 7, 9, 9  …  29, 34, 34, 34, 34, 34, 34, 34, 21, 20]
+
+length(read)
+# 60
+
+read[3:12]
+# FASTX.FASTQ.FASTQRead{BioSequences.DNAAlphabet{4}}:
+#    identifier: SEQ_ID
+#   description: 
+#      sequence: TTTGGGGTTC
+#       quality: [6, 9, 7, 7, 7, 7, 9, 9, 9, 10]
+
+read[3:12].sequence
+# 10nt DNA Sequence:
+# TTTGGGGTTC
+
+read[1:3].quality
+# 3-element Array{UInt8,1}:
+#  0x00
+#  0x06
+#  0x06
+```

--- a/docs/src/manual/fastq.md
+++ b/docs/src/manual/fastq.md
@@ -132,14 +132,14 @@ The FASTQ Read data structure is better suited for sequence manipulations:
 
 - Identifier and description are Strings.
 - Sequence is stored as a `BioSequence` and not just as ASCII characters.
-- The quality is stored as raw PHRED-score (Integer), and there is no offset to worry about.
+- The quality is stored as raw PHRED-score (Integer), and there is no offset to worry about after the conversion.
 
 A FASTQ Read record also allows for convenient sub-setting using normal range syntax as for Arrays and Strings:
 
 ```jlcon
 using FASTX
 
-read = FASTQ.Read(first(FASTQ.Reader(open("my-reads.fastq", "r"))),33)
+read = FASTQ.Read(first(FASTQ.Reader(open("my-reads.fastq", "r"))))
 # FASTX.FASTQ.FASTQRead{BioSequences.DNAAlphabet{4}}:
 #    identifier: SEQ_ID
 #   description: 
@@ -166,3 +166,16 @@ read[1:3].quality
 #  0x06
 #  0x06
 ```
+
+When defining the FASTQ.Read object, the quality can be given as an integer offset or encoding symbol.
+
+```jlcon
+rec = first(FASTQ.Reader(open("my-reads.fastq", "r")));
+r1 = FASTQ.FASTQ.Read(rec, 33);
+r2 = FASTQ.FASTQ.Read(rec, :illumina18);
+r1.quality == r2.quality
+# true
+```
+
+The platform specific quality encodings are described on [wikipedia](https://en.wikipedia.org/wiki/FASTQ_format#Encoding).
+

--- a/src/fastq/fastq.jl
+++ b/src/fastq/fastq.jl
@@ -15,5 +15,6 @@ include("record.jl")
 include("readrecord.jl")
 include("reader.jl")
 include("writer.jl")
+include("fastqread.jl")
 
 end

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -12,6 +12,7 @@ end
 
 """
     FASTQ.Read(record::FASTQ.Record, offset::Integer=33)
+    FASTQ.Read(record::FASTQ.Record, encoding_name::Symbol)
 
 Create a FASTQ read object from a FASTQ.Record.
 The FASTQ.Read has fields: 
@@ -26,6 +27,15 @@ function Read(record::FASTQ.Record, offset::Integer=33)
         description(record),
         sequence(record),
         quality(record, offset)
+    )
+end
+
+function Read(record::FASTQ.Record, encoding_name::Symbol)
+    FASTQRead(
+        identifier(record),
+        description(record),
+        sequence(record),
+        quality(record, encoding_name)
     )
 end
 

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -41,6 +41,10 @@ function Base.length(read::FASTQ.FASTQRead)
     length(read.sequence)
 end
 
+"""
+     Base.getindex(record::Record, i::UnitRange{Int})
+Subset a FASTQRead using string syntax. Eg. read[3:7]
+"""
 function Base.getindex(read::FASTQ.FASTQRead, i::UnitRange{<:Integer})
     return FASTQRead(
         read.identifier,

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -1,0 +1,46 @@
+# FASTQ Read
+# ==========
+#
+# Design discussions in https://github.com/BioJulia/FASTX.jl/pull/35
+
+mutable struct FASTQRead
+    identifier::String
+    description::String
+    sequence::BioSequences.LongDNASeq
+    quality::Vector{UInt8} # in raw PHRED scores, not offset
+end
+
+
+function Read(record::Record, offset::Integer=33)
+    FASTQRead(
+        identifier(record),
+        description(record),
+        sequence(BioSequences.LongDNASeq, record),
+        quality(record, offset)
+    )
+end
+
+function sequence(read::Read)
+    read.sequence
+end
+
+function quality(read::Read)
+    read.quality
+end
+
+function Base.length(read)
+    length(read.lequence)
+end
+
+function Base.getindex(read::Read, i::UnitRange{Int})
+    return Read(
+        read.identifier,
+        read.description,
+        read.sequence[i],
+        read.quality[i]
+    )
+end
+
+function Base.getindex(read::Read, i::Int)
+    read[i:i]
+end

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -41,7 +41,7 @@ function Base.length(read::FASTQ.FASTQRead)
     length(read.sequence)
 end
 
-function Base.getindex(read::FASTQ.FASTQRead, i::UnitRange{Int})
+function Base.getindex(read::FASTQ.FASTQRead, i::UnitRange{<:Integer})
     return FASTQRead(
         read.identifier,
         read.description,
@@ -50,7 +50,7 @@ function Base.getindex(read::FASTQ.FASTQRead, i::UnitRange{Int})
     )
 end
 
-function Base.getindex(read::FASTQRead, i::Int)
+function Base.getindex(read::FASTQRead, i::Integer)
     read[i:i]
 end
 

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -3,10 +3,10 @@
 #
 # Design discussions in https://github.com/BioJulia/FASTX.jl/pull/35
 
-mutable struct FASTQRead
+struct FASTQRead{A <: BioSequences.Alphabet}
     identifier::String
     description::String
-    sequence::BioSequences.LongDNASeq
+    sequence::BioSequences.LongSequence{A}
     quality::Vector{UInt8} # in raw PHRED scores, not offset
 end
 

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -69,8 +69,8 @@ Subset a FASTQRead using string syntax. Eg. read[3:7] or read[3]
 """
 function Base.getindex(read::FASTQ.FASTQRead, i::UnitRange{<:Integer})
     return FASTQRead(
-        read.identifier,
-        read.description,
+        join([read.identifier,string(i[1],"..",i[end])],"_"),
+        join([read.description,string(i[1],"..",i[end])]," "),
         read.sequence[i],
         read.quality[i]
     )

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -24,7 +24,7 @@ function Read(record::FASTQ.Record, offset::Integer=33)
     FASTQRead(
         identifier(record),
         description(record),
-        sequence(BioSequences.LongDNASeq, record),
+        sequence(record),
         quality(record, offset)
     )
 end

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -10,8 +10,17 @@ mutable struct FASTQRead
     quality::Vector{UInt8} # in raw PHRED scores, not offset
 end
 
+"""
+    FASTQ.Read(record::FASTQ.Record, offset::Integer=33)
 
-function Read(record::Record, offset::Integer=33)
+Create a FASTQ read object from a FASTQ.Record.
+The FASTQ.Read has fields: 
+    identifier::String
+    description::String
+    sequence::BioSequences.LongDNASeq
+    quality::Vector{UInt8} # in raw PHRED scores, not offset
+"""
+function Read(record::FASTQ.Record, offset::Integer=33)
     FASTQRead(
         identifier(record),
         description(record),
@@ -20,20 +29,20 @@ function Read(record::Record, offset::Integer=33)
     )
 end
 
-function sequence(read::Read)
+function sequence(read::FASTQ.FASTQRead)
     read.sequence
 end
 
-function quality(read::Read)
+function quality(read::FASTQ.FASTQRead)
     read.quality
 end
 
-function Base.length(read)
-    length(read.lequence)
+function Base.length(read::FASTQ.FASTQRead)
+    length(read.sequence)
 end
 
-function Base.getindex(read::Read, i::UnitRange{Int})
-    return Read(
+function Base.getindex(read::FASTQ.FASTQRead, i::UnitRange{Int})
+    return FASTQRead(
         read.identifier,
         read.description,
         read.sequence[i],
@@ -41,6 +50,15 @@ function Base.getindex(read::Read, i::UnitRange{Int})
     )
 end
 
-function Base.getindex(read::Read, i::Int)
+function Base.getindex(read::FASTQRead, i::Int)
     read[i:i]
+end
+
+function Base.show(io::IO, read::FASTQ.FASTQRead)
+    print(io, summary(read), ':')
+    println(io)
+    println(io, "   identifier: ", read.identifier)
+    println(io, "  description: ", read.description)
+    println(io, "     sequence: ", String(read.sequence))
+    print(io, "      quality: ", Int64.(quality(read)))
 end

--- a/src/fastq/fastqread.jl
+++ b/src/fastq/fastqread.jl
@@ -17,7 +17,7 @@ Create a FASTQ read object from a FASTQ.Record.
 The FASTQ.Read has fields: 
     identifier::String
     description::String
-    sequence::BioSequences.LongDNASeq
+    sequence::BioSequences.LongSequence
     quality::Vector{UInt8} # in raw PHRED scores, not offset
 """
 function Read(record::FASTQ.Record, offset::Integer=33)
@@ -29,21 +29,33 @@ function Read(record::FASTQ.Record, offset::Integer=33)
     )
 end
 
+"""
+    sequence(read::FASTQ.FASTQRead)
+Get the sequence of a FASTQ read. Same as read.sequence
+"""
 function sequence(read::FASTQ.FASTQRead)
     read.sequence
 end
 
+"""
+    quality(read::FASTQ.FASTQRead)
+Get the quality of a FASTQ read (Vector{UInt8}). Same as read.quality
+"""
 function quality(read::FASTQ.FASTQRead)
     read.quality
 end
 
+"""
+    length(read::FASTQ.FASTQRead)
+Get the length of a FASTQ read.
+"""
 function Base.length(read::FASTQ.FASTQRead)
     length(read.sequence)
 end
 
 """
      Base.getindex(record::Record, i::UnitRange{Int})
-Subset a FASTQRead using string syntax. Eg. read[3:7]
+Subset a FASTQRead using string syntax. Eg. read[3:7] or read[3]
 """
 function Base.getindex(read::FASTQ.FASTQRead, i::UnitRange{<:Integer})
     return FASTQRead(

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -103,6 +103,24 @@ function Base.copy(record::Record)
         record.quality)
 end
 
+"""
+     Base.getindex(record::Record, i::UnitRange{Int})
+Subset a FASTQ record using string syntax. Eg. rec[3:7]
+"""
+function Base.getindex(record::Record, i::UnitRange{Int})
+    return Record(
+        record.data,
+        record.filled,
+        record.identifier,
+        record.description,
+        record.sequence[i],
+        record.quality[i]
+    )
+end
+function Base.getindex(record::Record, i::Int)
+    record[i:i]
+end
+
 function Base.write(io::IO, record::Record)
     return unsafe_write(io, pointer(record.data, first(record.filled)), length(record.filled))
 end

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -103,24 +103,6 @@ function Base.copy(record::Record)
         record.quality)
 end
 
-"""
-     Base.getindex(record::Record, i::UnitRange{Int})
-Subset a FASTQ record using string syntax. Eg. rec[3:7]
-"""
-function Base.getindex(record::Record, i::UnitRange{Int})
-    return Record(
-        record.data,
-        record.filled,
-        record.identifier,
-        record.description,
-        record.sequence[i],
-        record.quality[i]
-    )
-end
-function Base.getindex(record::Record, i::Int)
-    record[i:i]
-end
-
 function Base.write(io::IO, record::Record)
     return unsafe_write(io, pointer(record.data, first(record.filled)), length(record.filled))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -462,6 +462,25 @@ end
         seekstart(input)
         @test FASTQ.sequence(LongSequence{DNAAlphabet{2}}, first(FASTQ.Reader(input, fill_ambiguous=DNA_A))) == dna"ACGTAAACGTAA"
     end
+
+    @testset "Reads" begin
+        record = FASTQ.Record("""
+                   @SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
+                   AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA
+                   +SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
+                   @BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ
+                   """)
+        r1 = FASTQ.Read(record,33)
+        @test String(r1.sequence) == "AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA"
+        @test Int64.(r1.quality)[1:5] == [31, 33, 34, 37, 37]
+        @test length(r1) == 45
+        @test String(sequence(r1)) == "AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA"
+        @test Int64.(quality(r1))[1:5] == [31, 33, 34, 37, 37]
+        @test String(r1[3:6].sequence) == "GCTC"
+        @test Int64.(r1[3:6].quality) == [34,37,37,37]
+        @test String(r1[3].sequence) == "G"
+    end
+    
 end
 
 @testset "Quality scores" begin
@@ -520,5 +539,6 @@ end
                     Int8[0, 2, 3, 4, 5, 40, 93],
                     UInt8['!', '#', '$', '%', '&', 'I', '~'])
     end
+
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -308,6 +308,8 @@ end
         @test FASTQ.sequence(String, record) == "AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA"
         @test FASTQ.hasquality(record)
         @test FASTQ.quality(record) == b"@BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ" .- 33
+        @test FASTQ.sequence(String, record[3:6]) == "GCTC"
+        @test FASTQ.quality(record[3:6]) == b"CFFF" .- 33
 
         record1 = FASTQ.Record("id", "desc", "AAGCT", collect("@BCFF"))
         record2 = FASTQ.Record("id", "desc", "AAGCT", collect("@BCFF"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -463,7 +463,7 @@ end
         @test FASTQ.sequence(LongSequence{DNAAlphabet{2}}, first(FASTQ.Reader(input, fill_ambiguous=DNA_A))) == dna"ACGTAAACGTAA"
     end
 
-    @testset "Reads" begin
+    @testset "FASTQRead" begin
         record = FASTQ.Record("""
                    @SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
                    AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA
@@ -479,6 +479,7 @@ end
         @test String(r1[3:6].sequence) == "GCTC"
         @test Int64.(r1[3:6].quality) == [34,37,37,37]
         @test String(r1[3].sequence) == "G"
+        @test sprint(show, r1) == "FASTX.FASTQ.FASTQRead:\n   identifier: SRR1238088.1.1\n  description: HWI-ST499:111:D0G94ACXX:1:1101:1173:2105\n     sequence: AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA\n      quality: [31, 33, 34, 37, 37, 37, 35, 37, 39, 39, 39, 39, 39, 41, 41, 41, 40, 41, 40, 41, 41, 40, 41, 41, 41, 41, 41, 41, 41, 41, 40, 41, 41, 41, 41, 40, 40, 40, 41, 41, 41, 40, 41, 41, 41]"
     end
     
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -467,7 +467,9 @@ end
                    +SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
                    @BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ
                    """)
-        r1 = FASTQ.Read(record,33)
+        r1 = FASTQ.Read(record)
+        r2 = FASTQ.Read(record,:sanger)
+        @test r1.quality == r2.quality
         @test String(r1.sequence) == "AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA"
         @test Int64.(r1.quality)[1:5] == [31, 33, 34, 37, 37]
         @test length(r1) == 45

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -479,7 +479,7 @@ end
         @test String(r1[3:6].sequence) == "GCTC"
         @test Int64.(r1[3:6].quality) == [34,37,37,37]
         @test String(r1[3].sequence) == "G"
-        @test sprint(show, r1) == "FASTX.FASTQ.FASTQRead:\n   identifier: SRR1238088.1.1\n  description: HWI-ST499:111:D0G94ACXX:1:1101:1173:2105\n     sequence: AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA\n      quality: [31, 33, 34, 37, 37, 37, 35, 37, 39, 39, 39, 39, 39, 41, 41, 41, 40, 41, 40, 41, 41, 40, 41, 41, 41, 41, 41, 41, 41, 41, 40, 41, 41, 41, 41, 40, 40, 40, 41, 41, 41, 40, 41, 41, 41]"
+        @test sprint(show, r1) == "FASTX.FASTQ.FASTQRead{DNAAlphabet{4}}:\n   identifier: SRR1238088.1.1\n  description: HWI-ST499:111:D0G94ACXX:1:1101:1173:2105\n     sequence: AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA\n      quality: [31, 33, 34, 37, 37, 37, 35, 37, 39, 39, 39, 39, 39, 41, 41, 41, 40, 41, 40, 41, 41, 40, 41, 41, 41, 41, 41, 41, 41, 41, 40, 41, 41, 41, 41, 40, 40, 40, 41, 41, 41, 40, 41, 41, 41]"
     end
     
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -308,9 +308,6 @@ end
         @test FASTQ.sequence(String, record) == "AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA"
         @test FASTQ.hasquality(record)
         @test FASTQ.quality(record) == b"@BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ" .- 33
-        @test FASTQ.sequence(String, record[3:6]) == "GCTC"
-        @test FASTQ.sequence(String, record[3]) == "G"
-        @test FASTQ.quality(record[3:6]) == b"CFFF" .- 33
 
         record1 = FASTQ.Record("id", "desc", "AAGCT", collect("@BCFF"))
         record2 = FASTQ.Record("id", "desc", "AAGCT", collect("@BCFF"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -309,6 +309,7 @@ end
         @test FASTQ.hasquality(record)
         @test FASTQ.quality(record) == b"@BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ" .- 33
         @test FASTQ.sequence(String, record[3:6]) == "GCTC"
+        @test FASTQ.sequence(String, record[3]) == "G"
         @test FASTQ.quality(record[3:6]) == b"CFFF" .- 33
 
         record1 = FASTQ.Record("id", "desc", "AAGCT", collect("@BCFF"))


### PR DESCRIPTION
# Subsetting FASTQ record using string syntax

## Types of changes

This PR implements the following changes:

* [X] :sparkles: New feature (A non-breaking change which adds functionality).

* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

This implements Base.getindex to allow subsetting of fastq records using string syntax:

```
record = FASTQ.Record("""
               @SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
               AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA
               +SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
               @BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ
               """)

julia> record[3:6]
FASTX.FASTQ.Record:
   identifier: SRR1238088.1.1
  description: HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
     sequence: GCTC
      quality: UInt8[0x22, 0x25, 0x25, 0x25]
```

This addition was proposed in #34 

## :ballot_box_with_check: Checklist

- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [X] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [X] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [X] :ok: There are unit tests that cover the code changes I have made.
- [X] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
- [X] :thought_balloon: I have commented liberally for any complex pieces of internal code.
