### PR TITLE
Avoid copying data when extracting sequence

### DIFF
--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -215,8 +215,7 @@ If `part` argument is given, it returns the specified part of the sequence.
 """
 function sequence(::Type{S}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::S where S <: BioSequences.LongSequence
     checkfilled(record)
-    seqpart = record.sequence[part]
-    return S(record.data, first(seqpart), last(seqpart))
+    return S(view(record.data, record.sequence[part]))
 end
 
 function sequence(::Type{String}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::String

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -243,8 +243,7 @@ If `part` argument is given, it returns the specified part of the sequence.
 """
 function sequence(::Type{S}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::S where S <: BioSequences.LongSequence
     checkfilled(record)
-    seqpart = record.sequence[part]
-    return S(record.data, first(seqpart), last(seqpart))
+    return S(view(record.data, record.sequence[part]))
 end
 
 """


### PR DESCRIPTION
Uses a view instead of slicing into the `data` vector when creating the sequence, hence saving a copy of the data.