### PR TITLE
Fix description newline bug

### DIFF
--- a/src/fasta/readrecord.jl
+++ b/src/fasta/readrecord.jl
@@ -12,11 +12,11 @@ machine = (function ()
     identifier.actions[:enter] = [:pos]
     identifier.actions[:exit]  = [:identifier]
     
-    description = re.cat(re.any() \ hspace, re"[^\r\n]*")
+    description = re.cat(re.any() \ re.space(), re"[^\n\r]*")
     description.actions[:enter] = [:pos]
     description.actions[:exit]  = [:description]
-    
-    header = re.cat('>', identifier, re.opt(re.cat(re.rep1(hspace), description)))
+
+    header = re">" * identifier * re.opt(re.rep1(hspace) * re.opt(description))
     header.actions[:enter] = [:mark]
     header.actions[:exit]  = [:header]
     

--- a/src/fastq/readrecord.jl
+++ b/src/fastq/readrecord.jl
@@ -10,11 +10,11 @@ machine = (function ()
         identifier.actions[:enter] = [:pos]
         identifier.actions[:exit]  = [:header1_identifier]
         
-        description = re.cat(re.any() \ hspace, re"[^\r\n]*")
+        description = re.cat(re.any() \ re.space(), re"[^\r\n]*")
         description.actions[:enter] = [:pos]
         description.actions[:exit]  = [:header1_description]
         
-        re.cat('@', identifier, re.opt(re.cat(re.rep1(hspace), description)))
+        re.cat('@', identifier, re.opt(re.cat(re.rep1(hspace), re.opt(description))))
     end
     
     sequence = re"[A-z]*"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,11 @@ import BioSequences:
         @test FASTA.header(record) == "CYS1_DICDI fragment"
         @test FASTA.sequence(record) == aa"SCWSFSTTGNVEGQHFISQNKLVSLSEQNLVDCDHECMEYEGE"
         @test FASTA.sequence(record, 10:15) == aa"NVEGQH"
+
+        # PR 37
+        s = ">A \nTAG\n"
+        rec = first(iterate(FASTA.Reader(IOBuffer(s))))
+        @test isempty(rec.description)
     end
 
     output = IOBuffer()
@@ -291,6 +296,11 @@ end
     +2 high quality
     IJN
     """
+
+    # PR 37
+    s = "@A \nTAG\n+\nJJJ\n"
+    rec = first(iterate(FASTQ.Reader(IOBuffer(s))))
+    @test isempty(rec.description)
     
     # Test issue 25
     lines = ["@A", "A", "+", "F", "@B", "CA", "+", "CF"]


### PR DESCRIPTION
MWE before:
```
julia> dump(first(iterate(FASTA.Reader(IOBuffer(">A \nTAG\n")))))
FASTX.FASTA.Record
  data: Array{UInt8}((8,)) UInt8[0x3e, 0x41, 0x20, 0x0a, 0x54, 0x41, 0x47, 0x0a]
  filled: UnitRange{Int64}
    start: Int64 1
    stop: Int64 8
  identifier: UnitRange{Int64}
    start: Int64 2
    stop: Int64 2
  description: UnitRange{Int64}
    start: Int64 4
    stop: Int64 7
  sequence: UnitRange{Int64}
    start: Int64 1
    stop: Int64 0
```
Note that the sequence `TAG` is parsed as part of the description.

After:
```
julia> dump(first(iterate(FASTA.Reader(IOBuffer(">A \nTAG\n")))))
FASTX.FASTA.Record
  data: Array{UInt8}((7,)) UInt8[0x3e, 0x41, 0x20, 0x0a, 0x54, 0x41, 0x47]
  filled: UnitRange{Int64}
    start: Int64 1
    stop: Int64 7
  identifier: UnitRange{Int64}
    start: Int64 2
    stop: Int64 2
  description: UnitRange{Int64}
    start: Int64 1
    stop: Int64 0
  sequence: UnitRange{Int64}
    start: Int64 5
    stop: Int64 7
```