### PR TITLE
Fix FASTQ line counting bug

### DIFF
--- a/src/fastq/readrecord.jl
+++ b/src/fastq/readrecord.jl
@@ -40,7 +40,7 @@ machine = (function ()
     end
 
     sep = re.opt('\r') * re"\n"
-    sep.actions[:exit] = [:sep, :countline]
+    sep.actions[:exit] = [:countline, :sep]
     
     record = re.cat(header1, newline, sequence, newline, header2, newline, quality)
     record.actions[:enter] = [:mark]


### PR DESCRIPTION
MWE:
```julia
using FASTX
s = join(collect("@A+J@A/J"), '\n')
println(collect(FASTQ.Reader(IOBuffer(s))))
```
Output:
```julia
ERROR: LoadError: ArgumentError: malformed FASTQ file at line 6
```
But the mistake is actually on line 7, not line 6. The problem was a previous change I had made in #28 , where I accidentally had the `@escape` action before the `@countline` action, so the latter was never taken.