### PR TITLE
Add quality and sequence iterator

### DIFF
--- a/src/fasta/fasta.jl
+++ b/src/fasta/fasta.jl
@@ -10,6 +10,7 @@ import BioGenerics: BioGenerics, isfilled
 import BioGenerics.Exceptions: missingerror
 import BioGenerics.Automa: State
 import BioSequences
+import BioSymbols
 import TranscodingStreams: TranscodingStreams, TranscodingStream
 import ..FASTX: identifier, description, sequence
 

--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -213,6 +213,21 @@ function header(record::Record)
 end
 
 """
+    sequence_iter(T, record::Record)
+
+Yields an iterator of the sequence, with elements of type `T`. `T` is constructed
+through `T(Char(x))` for each byte `x`. E.g. `sequence_iter(DNA, record)`.
+Mutating the record will corrupt the iterator.
+"""
+function sequence_iter(::Type{T}, record::Record,
+    part::UnitRange{<:Integer}=1:lastindex(record.sequence)) where {T <: BioSymbols.BioSymbol}
+    checkfilled(record)
+    seqpart = record.sequence[part]
+    data = record.data
+    return (T(Char(@inbounds (data[i]))) for i in seqpart)
+end
+
+"""
     sequence(::Type{S}, record::Record, [part::UnitRange{Int}])::S
 
 Get the sequence of `record`.

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -241,6 +241,21 @@ function Base.copyto!(dest::BioSequences.LongSequence, doff, src::Record, soff, 
 end
 
 """
+    sequence_iter(T, record::Record)
+
+Yields an iterator of the sequence, with elements of type `T`. `T` is constructed
+through `T(Char(x))` for each byte `x`. E.g. `sequence_iter(DNA, record)`.
+Mutating the record will corrupt the iterator.
+"""
+function sequence_iter(::Type{T}, record::Record,
+    part::UnitRange{<:Integer}=1:lastindex(record.sequence)) where {T <: BioSymbols.BioSymbol}
+    checkfilled(record)
+    seqpart = record.sequence[part]
+    data = record.data
+    return (T(Char(@inbounds (data[i]))) for i in seqpart)
+end
+
+"""
     sequence(::Type{S}, record::Record, [part::UnitRange{Int}])
 
 Get the sequence of `record`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using FASTX
 using FormatSpecimens
+using BioSymbols
 import BioGenerics
 import BioGenerics.Testing: intempdir
 import BioSequences:
@@ -35,7 +36,8 @@ import BioSequences:
         @test BioGenerics.hassequence(record)
         @test FASTA.hassequence(record)
         @test FASTA.sequence(record) == dna"ACGT"
-        @test FASTA.sequence(record, 2:3) == dna"CG"
+        @test collect(FASTA.sequence_iter(DNA, record)) == [DNA_A, DNA_C, DNA_G, DNA_T] 
+        @test FASTA.sequence(record, 2:3) == LongDNASeq(collect(FASTA.sequence_iter(DNA, record, 2:3))) == dna"CG"
         @test FASTA.sequence(String, record) == "ACGT"
         @test FASTA.sequence(String, record, 2:3) == "CG"
 
@@ -331,6 +333,8 @@ end
         @test FASTQ.header(record) == FASTQ.identifier(record) * " " * FASTA.description(record)
         @test FASTQ.hassequence(record) == BioGenerics.hassequence(record) == true
         @test FASTQ.sequence(LongDNASeq, record) == seq
+        @test LongDNASeq(collect(FASTQ.sequence_iter(DNA, record))) == seq
+        @test LongDNASeq(collect(FASTQ.sequence_iter(DNA, record, 3:7))) == dna"GCTCA"
         @test copyto!(LongDNASeq(FASTQ.seqlen(record)), record) == seq
         @test_throws ArgumentError copyto!(LongDNASeq(10), FASTQ.Record())
         @test FASTQ.sequence(record) == BioGenerics.sequence(record) == seq


### PR DESCRIPTION
As described in #40 , this adds a small PR to obtain the sequence and quality from FASTA/FASTQ files without allocating a new vector.