### PR TITLE
Model good behavior with do block syntax

### DIFF
--- a/docs/src/manual/fasta.md
+++ b/docs/src/manual/fasta.md
@@ -38,24 +38,29 @@ using FASTX
 r = FASTA.Reader(open("my-seqs.fasta", "r"))
 w = FASTA.Writer(open("my-out.fasta", "w"))
 ```
+As always with julia IO types, remember to close your file readers and writer
+after you are finished.
 
-Alternatively, `Base.open` is overloaded with a method for conveinience:
+Using `open` with a do-block can help ensure you close a stream after you are
+finished. `Base.open` is overloaded with a method for this purpose.
 
 ```jlcon
 r = open(FASTA.Reader, "my-seqs.fasta")
 w = open(FASTA.Writer, "my-out.fasta")
 ```
 
+
+
 Usually sequence records will be read sequentially from a file by iteration.
 
 ```jlcon
-reader = open(FASTA.Reader, "my-seqs.fasta")
-for record in reader
-    ## Do something
-    # like showing the identifiers
-    @show FASTA.identifier(record)
+open(FASTA.Reader, "my-seqs.fasta") do reader
+    for record in reader
+        ## Do something
+        # like showing the identifiers
+        @show FASTA.identifier(record)
+    end
 end
-close(reader)
 ```
 
 Gzip compressed files can be streamed to the `Reader`
@@ -72,11 +77,12 @@ close(reader)
 You can also overwrite records in a while loop to avoid excessive memory allocation.
 
 ```jlcon
-reader = open(FASTA.Reader, "my-seqs.fasta")
-record = FASTA.Record()
-while !eof(reader)
-    read!(reader, record)
-    ## Do something.
+open(FASTA.Reader, "my-seqs.fasta") do reader
+    record = FASTA.Record()
+    while !eof(reader)
+        read!(reader, record)
+        ## Do something.
+    end
 end
 ```
 
@@ -85,9 +91,9 @@ supports random access to FASTA records, which would be useful when accessing
 specific parts of a huge genome sequence:
 
 ```jlcon
-reader = open(FASTA.Reader, "sacCer.fa", index = "sacCer.fa.fai")
-chrIV = reader["chrIV"]  # directly read sequences called chrIV.
-close(reader)
+open(FASTA.Reader, "sacCer.fa", index = "sacCer.fa.fai") do reader
+    chrIV = reader["chrIV"]  # directly read sequences called chrIV.
+end
 ```
 
 Reading in a sequence from a FASTA formatted file will give you a variable of
@@ -108,21 +114,7 @@ To write a `BioSequence` to FASTA file, you first have to create a [`FASTA.Recor
 using BioSequences
 x = dna"aaaaatttttcccccggggg"
 rec = FASTA.Record("MySeq", x)
-w = open(FASTA.Writer, "my-out.fasta")
-write(w, rec)
-close(w)
-```
-
-As always with julia IO types, remember to close your file readers and writer
-after you are finished.
-
-Using `open` with a do-block can help ensure you close a stream after you are
-finished.
-
-```jlcon
-open(FASTA.Reader, "my-reads.fasta") do reader
-    for record in reader
-        ## Do something
-    end
+open(FASTA.Writer, "my-out.fasta") do
+    write(w, rec)
 end
 ```

--- a/docs/src/manual/fasta.md
+++ b/docs/src/manual/fasta.md
@@ -38,6 +38,7 @@ using FASTX
 r = FASTA.Reader(open("my-seqs.fasta", "r"))
 w = FASTA.Writer(open("my-out.fasta", "w"))
 ```
+
 As always with julia IO types, remember to close your file readers and writer
 after you are finished.
 
@@ -48,8 +49,6 @@ finished. `Base.open` is overloaded with a method for this purpose.
 r = open(FASTA.Reader, "my-seqs.fasta")
 w = open(FASTA.Writer, "my-out.fasta")
 ```
-
-
 
 Usually sequence records will be read sequentially from a file by iteration.
 

--- a/docs/src/manual/fastq.md
+++ b/docs/src/manual/fastq.md
@@ -41,7 +41,11 @@ r = FASTQ.Reader(open("my-reads.fastq", "r"))
 w = FASTQ.Writer(open("my-output.fastq", "w"))
 ```
 
-Alternatively, `Base.open` is overloaded with a method for conveinience:
+As always with julia IO types, remember to close your file readers and writer
+after you are finished.
+
+Using `open` with a do-block can help ensure you close a stream after you are
+finished. `Base.open` is overloaded with a method for this purpose.
 
 ```jlcon
 r = open(FASTQ.Reader, "my-reads.fastq")
@@ -52,11 +56,11 @@ Note that [`FASTQ.Reader`](@ref) does not support line-wraps within sequence and
 Usually sequence records will be read sequentially from a file by iteration.
 
 ```jlcon
-reader = open(FASTQ.Reader, "my-reads.fastq")
-for record in reader
-    ## Do something
+open(FASTQ.Reader, "my-reads.fastq") do reader
+    for record in reader
+        ## Do something
+    end
 end
-close(reader)
 ```
 
 Gzip compressed files can be streamed to the `Reader`
@@ -73,11 +77,12 @@ close(reader)
 You can also overwrite records in a while loop to avoid excessive memory allocation.
 
 ```jlcon
-reader = open(FASTQ.Reader, "my-reads.fastq")
-record = FASTQ.Record()
-while !eof(reader)
-    read!(reader, record)
-    ## Do something.
+open(FASTQ.Reader, "my-reads.fastq") do reader
+    record = FASTQ.Record()
+    while !eof(reader)
+        read!(reader, record)
+        ## Do something.
+    end
 end
 ```
 
@@ -96,20 +101,6 @@ Various getters and setters are available for [`FASTQ.Record`](@ref)s:
 - [`FASTQ.quality`](@ref)
 
 To write a `BioSequence` to FASTQ file, you first have to create a [`FASTQ.Record`](@ref):
-
-As always with julia IO types, remember to close your file readers and writer
-after you are finished.
-
-Using `open` with a do-block can help ensure you close a stream after you are
-finished.
-
-```jlcon
-open(FASTQ.Reader, "my-reads.fastq") do reader
-    for record in reader
-        ## Do something
-    end
-end
-```
 
 ## Quality encodings
 
@@ -178,4 +169,3 @@ r1.quality == r2.quality
 ```
 
 The platform specific quality encodings are described on [wikipedia](https://en.wikipedia.org/wiki/FASTQ_format#Encoding).
-


### PR DESCRIPTION
The current docs don't use the `open/do/end` syntax and then just provide a warning at the end. I modified the docs to use it in most examples and move the explanation earlier in the docs to when the `open` convenience syntax is introduced.