### PR TITLE
Fix header code

### DIFF
--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -205,10 +205,10 @@ end
 
 Returns the stripped header line of `record`, or `nothing` if it was empty.
 """
-function header(record::Record)
-    hasidentifier(record) || return nothing
-    id, desc = record.identifier, record.description
-    range = first(id) : max(last(id), last(desc))
+function header(record::Record)::Union{String, Nothing}
+    id, de = record.identifier, record.description
+    isempty(id) && isempty(de) && return nothing
+    range = isempty(de) ? id : (isempty(id) ? de : first(id):last(de))
     return String(record.data[range])
 end
 

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -207,10 +207,10 @@ end
 
 Returns the stripped header line of `record`, or `nothing` if it was empty.
 """
-function header(record::Record)
-    hasidentifier(record) || return nothing
-    id, desc = record.identifier, record.description
-    range = first(id) : max(last(id), last(desc))
+function header(record::Record)::Union{String, Nothing}
+    id, de = record.identifier, record.description
+    isempty(id) && isempty(de) && return nothing
+    range = isempty(de) ? id : (isempty(id) ? de : first(id):last(de))
     return String(record.data[range])
 end
 


### PR DESCRIPTION
Fix bug. MWE:
```julia
julia> isnothing(FASTA.header(FASTA.Record("> hello\nTAG")))
true
```

I did not consider that a record may have an empty identifier but not an empty description.