### PR TITLE
Disallow record construction from anything

### DIFF
--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -63,7 +63,7 @@ end
 
 Create a FASTA record object from `identifier`, `description` and `sequence`.
 """
-function Record(identifier::AbstractString, description::Union{AbstractString,Nothing}, sequence)
+function Record(identifier::AbstractString, description::Union{AbstractString,Nothing}, sequence::Union{BioSequences.BioSequence, AbstractString})
     buf = IOBuffer()
     print(buf, '>', strip(identifier))
     if description != nothing

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -66,7 +66,7 @@ end
 
 Create a FASTQ record from `identifier`, `description`, `sequence` and `quality`.
 """
-function Record(identifier::AbstractString, description::Union{AbstractString,Nothing}, sequence, quality::Vector; offset=33)
+function Record(identifier::AbstractString, description::Union{AbstractString,Nothing}, sequence::Union{BioSequences.BioSequence, AbstractString}, quality::Vector; offset=33)
     if length(sequence) != length(quality)
         throw(ArgumentError("the length of sequence doesn't match the length of quality"))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,8 @@ import BioSequences:
         @test FASTA.sequence(String, record) == "ACGT"
         @test FASTA.sequence(String, record, 2:3) == "CG"
 
+        @test_throws MethodError FASTA.Record("header", nothing)
+
         record1 = FASTA.Record("id", "desc", "AGCT")
         record2 = FASTA.Record("id", "desc", "AGCT")
         @test record1 == record2


### PR DESCRIPTION
I just discovered this little gem:

```
julia> record = FASTA.Record("header", nothing)
FASTX.FASTA.Record:
   identifier: header
  description: <missing>
     sequence: nothing

julia> FASTA.sequence(record)
7aa Amino Acid Sequence:
NOTHING
```
This PR restricts the sequence to be of type `Union{BioSequence, AbstractString}`. I guess this is a breaking change, so maybe wait till a future release.