### PR TITLE
Call fill_ambiguous for FASTQ in all cases

### DIFF
--- a/src/fastq/readrecord.jl
+++ b/src/fastq/readrecord.jl
@@ -105,7 +105,8 @@ loopcode = quote
         if first_header_len != second_header_len || !is_same_mem(record.data, first_header_pos, second_header_pos, first_header_len)
             throw(ArgumentError("mismatched headers"))
         end
-    elseif found && transform != nothing
+    end
+    if found && transform != nothing
         transform(record.data, record.sequence)
     end
     found && @goto __return__


### PR DESCRIPTION
# Fix missing call to `fill_ambiguous` for FASTQ with second header (3rd line starting with `+`)

Former code called transform (aka fill_ambiguous) only if the second FASTQ header was missing.
This commit fixes this bug by calling it in every case if it available

## Types of changes

This PR implements the following changes:

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

- If you have changed current behaviour...
  - Former code called transform (aka fill_ambiguous) only if the second FASTQ header was missing.

  - `fill_ambiguous` is called after any successful parsing if the transformation is defined

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
