### PR TITLE
Allow trailing newlines for FASTQ files

### DIFF
--- a/src/fastq/readrecord.jl
+++ b/src/fastq/readrecord.jl
@@ -46,7 +46,7 @@ machine = (function ()
     record.actions[:enter] = [:mark]
     record.actions[:exit] = [:record]
     
-    fastq = re.rep(re.cat(record, sep)) * re.opt(record) * re.rep(newline)
+    fastq = re.rep(re.cat(record, sep)) * re.opt(record) * re.rep(sep)
     
     Automa.compile(fastq)
 end)()

--- a/src/fastq/readrecord.jl
+++ b/src/fastq/readrecord.jl
@@ -46,7 +46,7 @@ machine = (function ()
     record.actions[:enter] = [:mark]
     record.actions[:exit] = [:record]
     
-    fastq = re.rep(re.cat(record, sep)) * re.opt(record)
+    fastq = re.rep(re.cat(record, sep)) * re.opt(record) * re.rep(newline)
     
     Automa.compile(fastq)
 end)()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,7 +310,12 @@ end
     record = FASTQ.Record()
     read!(reader, record)
     read!(reader, record)
-    @test eof(reader)    
+    @test eof(reader)
+
+    # Test issue # 48 - allow trailing whitespace
+    reader = FASTQ.Reader(IOBuffer("@A\nTA\n+\nFF\n\n\n"))
+    @test length(collect(reader)) == 1
+    close(reader)
 
     @testset "Record" begin
         record = FASTQ.Record()


### PR DESCRIPTION
Fix issue #48 by allowing trailing newlines after FASTQ file.