### PR TITLE
Allow trailing whitespace in sequences

### DIFF
--- a/src/fasta/readrecord.jl
+++ b/src/fasta/readrecord.jl
@@ -30,8 +30,11 @@ machine = (function ()
         lf.actions[:enter] = [:countline]
         re.cat(re.opt('\r'), lf)
     end
-    
-    sequence = re.opt(re.cat(letters, re.rep(re.cat(re.rep1(re.alt(hspace, newline)), letters))))
+
+    # Sequence: A sequence can be any free combination of newline, letters and hspace
+    # It cannot be re.rep(letters | hspace | newline), because back-to-back repeated
+    # letters would cause an FSM ambiguity between nothing and [:letters, :mark]
+    sequence = re.rep(re.opt(letters) * (newline | hspace)) * re.opt(letters)
     
     record = re.cat(header, newline, sequence, re.rep1(newline))
     record.actions[:exit] = [:record]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,6 +183,11 @@ import BioSequences:
         test_fasta_parse(filename(specimen), false)
     end
 
+    # Test trailing whitespace
+    reader = FASTA.Reader(IOBuffer(">A\nTA \n>B C\nCA \nCC \n"))
+    @test length(collect(reader)) == 2
+    close(reader)
+
     @testset "Faidx" begin
         # Need to make sure it can handle mixed Unix and Windows newlines
         fastastr = """


### PR DESCRIPTION
Change the FSM definition for `sequence` to allow the following file: `">A\nA "` (i.e. allow whitespace after sequence lines)

I'm really not satisfied with this whack-a-mole process of continuing to refine the FSM definition until we've exhaused all the edge cases. We need a better test suite, or else create our own FASTA spec. Crossref #37 .

At any case, this fixes the issue and doesn't introduce any new issues that I'm aware of.