### PR TITLE
Transcode between FASTQ & FASTA files

### DIFF
--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -6,7 +6,8 @@ export
     identifier,
     description,
     sequence,
-    quality
+    quality,
+    transcode
 
 # Generic methods
 function identifier end
@@ -20,7 +21,13 @@ import .FASTA
 import .FASTQ
 import .FASTQ: quality
 
-FASTA.Record(fqrec::FASTQ.Record) = FASTA.Record(deleteat!(copy(fqrec.data), fqrec.quality))
+function FASTA.Record(record::FASTQ.Record)
+    FASTQ.checkfilled(record)
+    slice = (first(record.identifier) - 1):last(record.sequence)
+    newdata = @inbounds record.data[slice]
+    newdata[1] = 0x3E
+    FASTA.Record(newdata)
+end
 
 """
     transcode(in::FASTQ.Reader, out::FASTA.Writer)

--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -21,4 +21,18 @@ import .FASTQ
 import .FASTQ: quality
 
 FASTA.Record(fqrec::FASTQ.Record) = FASTA.Record(deleteat!(copy(fqrec.data), fqrec.quality))
+
+"""
+    transcode(in::FASTQ.Reader, out::FASTA.Writer)
+
+Convert a FASTQ file to a FASTA file.
+"""
+function transcode(in::FASTQ.Reader, out::FASTA.Writer)
+    buff_record = FASTQ.Record()
+    while !eof(in)
+        read!(in, buff_record)
+        write(out, FASTA.Record(buff_record))
+    end
+end
+
 end # module

--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -20,4 +20,5 @@ import .FASTA
 import .FASTQ
 import .FASTQ: quality
 
+FASTA.Record(fqrec::FASTQ.Record) = FASTA.Record(deleteat!(copy(fqrec.data), fqrec.quality))
 end # module

--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -7,7 +7,7 @@ export
     description,
     sequence,
     quality,
-    transcode
+    transcribe
 
 # Generic methods
 function identifier end
@@ -30,11 +30,11 @@ function FASTA.Record(record::FASTQ.Record)
 end
 
 """
-    transcode(in::FASTQ.Reader, out::FASTA.Writer)
+    transcribe(in::FASTQ.Reader, out::FASTA.Writer)
 
 Convert a FASTQ file to a FASTA file.
 """
-function transcode(in::FASTQ.Reader, out::FASTA.Writer)
+function transcribe(in::FASTQ.Reader, out::FASTA.Writer)
     buff_record = FASTQ.Record()
     while !eof(in)
         read!(in, buff_record)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -524,6 +524,17 @@ end
         @test sprint(show, r1) == "FASTX.FASTQ.FASTQRead{DNAAlphabet{4}}:\n   identifier: SRR1238088.1.1\n  description: HWI-ST499:111:D0G94ACXX:1:1101:1173:2105\n     sequence: AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA\n      quality: [31, 33, 34, 37, 37, 37, 35, 37, 39, 39, 39, 39, 39, 41, 41, 41, 40, 41, 40, 41, 41, 40, 41, 41, 41, 41, 41, 41, 41, 41, 40, 41, 41, 41, 41, 40, 40, 40, 41, 41, 41, 40, 41, 41, 41]"
     end
     
+    @testset "Conversion to FASTA" begin
+        fqrecord = FASTQ.Record("""
+                   @SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
+                   AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA
+                   +SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
+                   @BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ
+                   """)
+        @test sequence(FASTA.Record(fqrecord)) == sequence(fqrecord)
+        @test identifier(FASTA.Record(fqrecord)) == identifier(fqrecord)
+    end
+    
 end
 
 @testset "Quality scores" begin
@@ -584,4 +595,3 @@ end
     end
 
 end
-


### PR DESCRIPTION
For issue #50 

For a consistent conversion between HTS formats, we'll probably need a separate package with a more generic version of the `transcode` function I've implemented here. Possibly using `convert` and `promote`, although for this example a simple `FASTA.Record` constructor accepting a `FASTQ.Record` was enough.

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [X] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :ballot_box_with_check: Checklist

- [ ] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [ ] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
