### PR TITLE
Allow parsing FASTA record with no sequence

### DIFF
--- a/src/fasta/readrecord.jl
+++ b/src/fasta/readrecord.jl
@@ -36,7 +36,7 @@ machine = (function ()
     # letters would cause an FSM ambiguity between nothing and [:letters, :mark]
     sequence = re.rep(re.opt(letters) * (newline | hspace)) * re.opt(letters)
     
-    record = re.cat(header, newline, sequence, re.rep1(newline))
+    record = re.cat(header, re.opt(re.cat(newline, sequence)), re.rep1(newline))
     record.actions[:exit] = [:record]
     
     record_trailing = re.cat(header, re.rep1(newline), sequence)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,9 @@ import BioSequences:
     N
     """
 
+    # Test empty records
+    @test length(collect(FASTA.Reader(IOBuffer(">A\n>B\nTAG\n>C\nAA")))) == 3
+
     reader = FASTA.Reader(IOBuffer(
     """
     >seqA some description


### PR DESCRIPTION
I don't know if this is correct behaviour, but this PR allows the parsing of e.g:
```
>A
>B
AAA
```
