### PR TITLE
Export all user-facing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,4 @@ Your logo will show up here with a link to your website.
 
 
 ## Questions?
-
-If you have a question about contributing or using BioJulia software, come
-on over and chat to us on [Gitter](https://gitter.im/BioJulia/General), or you can try the
-[Bio category of the Julia discourse site](https://discourse.julialang.org/c/domain/bio).
+If you have a question about contributing or using BioJulia software, come on over and chat to us on [the Julia Slack workspace](https://julialang.org/slack/), or you can try the [Bio category of the Julia discourse site](https://discourse.julialang.org/c/domain/bio).

--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -4,22 +4,32 @@ export
     FASTA,
     FASTQ,
     identifier,
+    hasidentifier,
     description,
+    hasdescription,
+    header,
     sequence,
+    hassequence,
     quality,
+    hasquality,
+    quality_iter,
     transcribe
 
 # Generic methods
 function identifier end
 function description end
 function sequence end
+function hasidentifier end
+function hasdescription end
+function hassequence end
+function header end
 
 include("fasta/fasta.jl")
 include("fastq/fastq.jl")
 
 import .FASTA
 import .FASTQ
-import .FASTQ: quality
+import .FASTQ: quality, hasquality, quality_iter
 
 function FASTA.Record(record::FASTQ.Record)
     FASTQ.checkfilled(record)

--- a/src/fasta/fasta.jl
+++ b/src/fasta/fasta.jl
@@ -12,7 +12,9 @@ import BioGenerics.Automa: State
 import BioSequences
 import BioSymbols
 import TranscodingStreams: TranscodingStreams, TranscodingStream
-import ..FASTX: identifier, description, sequence
+import ..FASTX: identifier, hasidentifier,
+    description, hasdescription, header,
+    sequence, hassequence
 
 include("record.jl")
 include("index.jl")

--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -196,7 +196,7 @@ end
 
 Checks whether or not the `record` has a description.
 """
-function hasdescription(record)
+function hasdescription(record::Record)
     return isfilled(record) && !isempty(record.description)
 end
 

--- a/src/fastq/fastq.jl
+++ b/src/fastq/fastq.jl
@@ -8,7 +8,9 @@ import BioSequences
 import BioGenerics: BioGenerics, isfilled
 import BioGenerics.Automa: State
 import TranscodingStreams: TranscodingStreams, TranscodingStream
-import ..FASTX: identifier, description, sequence
+import ..FASTX: identifier, hasidentifier,
+    description, hasdescription, header,
+    sequence, hassequence
 
 include("quality.jl")
 include("record.jl")

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -193,7 +193,7 @@ end
 
 Checks whether or not the `record` has a description.
 """
-function hasdescription(record)
+function hasdescription(record::Record)
     return isfilled(record) && record.description != 1:0
 end
 


### PR DESCRIPTION
This exports `hassequence`, `hasdescription`, `header`, and other functions that are user-facing, but not exported.

I have not exported `FASTQRead`, because we do not agree about whether this should ultimately be in FASTX. https://github.com/BioJulia/FASTX.jl/pull/35#issuecomment-713198555