### PR TITLE
Return header, identifier and desc as string views

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,12 +1,15 @@
 name: TagBot
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.TAGBOT_KEY }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = [
     "Sabrina J. Ward <sabrinajward@protonmail.com>",
     "Jakob N. Nissen <jakobnybonissen@gmail.com>"
 ]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
@@ -16,8 +16,8 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [compat]
 Automa = "0.7, 0.8"
 BioGenerics = "0.1"
-BioSequences = "2.0.2"
-BioSymbols = "4"
+BioSequences = "3"
+BioSymbols = "5"
 TranscodingStreams = "0.9.5"
 julia = "1.6" # LTS
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
 BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
+StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
@@ -18,6 +19,7 @@ Automa = "0.7, 0.8"
 BioGenerics = "0.1"
 BioSequences = "3"
 BioSymbols = "5"
+StringViews = "1"
 TranscodingStreams = "0.9.5"
 julia = "1.6" # LTS
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,9 @@
 name = "FASTX"
 uuid = "c2308a5c-f048-11e8-3e8a-31650f418d12"
-authors = ["Ben J. Ward <benjward@protonmail.com>"]
+authors = [
+    "Sabrina J. Ward <sabrinajward@protonmail.com>",
+    "Jakob N. Nissen <jakobnybonissen@gmail.com>"
+]
 version = "1.2.0"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,4 @@ Your logo will show up here with a link to your website.
 
 
 ## Questions?
-
-If you have a question about contributing or using BioJulia software, come
-on over and chat to us on [Gitter](https://gitter.im/BioJulia/General), or you can try the
-[Bio category of the Julia discourse site](https://discourse.julialang.org/c/domain/bio).
+If you have a question about contributing or using BioJulia software, come on over and chat to us on [the Julia Slack workspace](https://julialang.org/slack/), or you can try the [Bio category of the Julia discourse site](https://discourse.julialang.org/c/domain/bio).

--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -4,22 +4,31 @@ export
     FASTA,
     FASTQ,
     identifier,
+    hasidentifier,
     description,
+    hasdescription,
+    header,
     sequence,
+    hassequence,
     quality,
-    transcribe
+    hasquality,
+    quality_iter
 
 # Generic methods
 function identifier end
 function description end
 function sequence end
+function hasidentifier end
+function hasdescription end
+function hassequence end
+function header end
 
 include("fasta/fasta.jl")
 include("fastq/fastq.jl")
 
 import .FASTA
 import .FASTQ
-import .FASTQ: quality
+import .FASTQ: quality, hasquality, quality_iter
 
 function FASTA.Record(record::FASTQ.Record)
     FASTQ.checkfilled(record)

--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -12,7 +12,8 @@ export
     hassequence,
     quality,
     hasquality,
-    quality_iter
+    quality_iter,
+    transcribe
 
 # Generic methods
 function identifier end

--- a/src/fasta/fasta.jl
+++ b/src/fasta/fasta.jl
@@ -11,6 +11,7 @@ import BioGenerics.Exceptions: missingerror
 import BioGenerics.Automa: State
 import BioSequences
 import BioSymbols
+import StringViews: StringView
 import TranscodingStreams: TranscodingStreams, TranscodingStream
 import ..FASTX: identifier, hasidentifier,
     description, hasdescription, header,

--- a/src/fasta/fasta.jl
+++ b/src/fasta/fasta.jl
@@ -12,7 +12,9 @@ import BioGenerics.Automa: State
 import BioSequences
 import BioSymbols
 import TranscodingStreams: TranscodingStreams, TranscodingStream
-import ..FASTX: identifier, description, sequence
+import ..FASTX: identifier, hasidentifier,
+    description, hasdescription, header,
+    sequence, hassequence
 
 include("record.jl")
 include("index.jl")

--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -243,7 +243,7 @@ If `part` argument is given, it returns the specified part of the sequence.
 function sequence(::Type{S}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::S where S <: BioSequences.LongSequence
     checkfilled(record)
     seqpart = record.sequence[part]
-    return S(record.data, first(seqpart), last(seqpart))
+    return S(@view(record.data[seqpart]))
 end
 
 function sequence(::Type{String}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::String
@@ -343,12 +343,12 @@ function predict_seqtype(seq::Vector{UInt8}, range)
     # the threshold (= 0.95) is somewhat arbitrary
     if (a + c + g + t + u + n) / alpha > 0.95
         if t ≥ u
-            return BioSequences.LongDNASeq
+            return BioSequences.LongDNA{4}
         else
-            return BioSequences.LongRNASeq
+            return BioSequences.LongRNA{4}
         end
     else
-        return BioSequences.LongAminoAcidSeq
+        return BioSequences.LongAA
     end
 end
 

--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -143,9 +143,11 @@ end
 # ------------------
 
 """
-    identifier(record::Record)::Union{String, Nothing}
+    identifier(record::Record)::Union{StringView, Nothing}
 
 Get the sequence identifier of `record`.
+Returns an `AbstractString` view into the record. If the record is overwritten,
+the string data will be corrupted.
 
 !!! note
     Returns nothing if the record has no identifier.
@@ -176,9 +178,11 @@ function BioGenerics.hasseqname(record::Record)
 end
 
 """
-    description(record::Record)::Union{String, Nothing}
+    description(record::Record)::Union{StringView, Nothing}
 
 Get the description of `record`.
+Returns an `AbstractString` view into the record. If the record is overwritten,
+the string data will be corrupted.
 
 !!! note
     Returns `nothing` if record has no description.
@@ -201,9 +205,11 @@ function hasdescription(record::Record)
 end
 
 """
-    header(record::Record)::Union{String, Nothing}
+    header(record::Record)::Union{StringView, Nothing}
 
 Returns the stripped header line of `record`, or `nothing` if it was empty.
+Returns an `AbstractString` view into the record. If the record is overwritten,
+the string data will be corrupted.
 """
 function header(record::Record)::Union{String, Nothing}
     id, de = record.identifier, record.description

--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -155,7 +155,7 @@ function identifier(record::Record)::Union{String, Nothing}
     if !hasidentifier(record)
         return nothing
     end
-    return String(record.data[record.identifier])
+    return StringView(view(record.data, record.identifier))
 end
 
 """
@@ -188,7 +188,7 @@ function description(record::Record)::Union{String, Nothing}
     if !hasdescription(record)
         return nothing
     end
-    return String(record.data[record.description])
+    return StringView(view(record.data, record.description))
 end
 
 """
@@ -209,7 +209,7 @@ function header(record::Record)::Union{String, Nothing}
     id, de = record.identifier, record.description
     isempty(id) && isempty(de) && return nothing
     range = isempty(de) ? id : (isempty(id) ? de : first(id):last(de))
-    return String(record.data[range])
+    return StringView(view(record.data, range))
 end
 
 """

--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -196,7 +196,7 @@ end
 
 Checks whether or not the `record` has a description.
 """
-function hasdescription(record)
+function hasdescription(record::Record)
     return isfilled(record) && !isempty(record.description)
 end
 

--- a/src/fastq/fastq.jl
+++ b/src/fastq/fastq.jl
@@ -8,7 +8,9 @@ import BioSequences
 import BioGenerics: BioGenerics, isfilled
 import BioGenerics.Automa: State
 import TranscodingStreams: TranscodingStreams, TranscodingStream
-import ..FASTX: identifier, description, sequence
+import ..FASTX: identifier, hasidentifier,
+    description, hasdescription, header,
+    sequence, hassequence
 
 include("quality.jl")
 include("record.jl")

--- a/src/fastq/fastq.jl
+++ b/src/fastq/fastq.jl
@@ -7,6 +7,7 @@ import BioSymbols
 import BioSequences
 import BioGenerics: BioGenerics, isfilled
 import BioGenerics.Automa: State
+import StringViews: StringView
 import TranscodingStreams: TranscodingStreams, TranscodingStream
 import ..FASTX: identifier, hasidentifier,
     description, hasdescription, header,

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -271,7 +271,7 @@ If `part` argument is given, it returns the specified part of the sequence.
 function sequence(::Type{S}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::S where S <: BioSequences.LongSequence
     checkfilled(record)
     seqpart = record.sequence[part]
-    return S(record.data, first(seqpart), last(seqpart))
+    return S(@view(record.data[seqpart]))
 end
 
 """
@@ -295,8 +295,8 @@ Get the sequence of `record` as a DNA sequence.
     If you have a sequence already and want to fill it with the sequence
     data contained in a fastq record, you can use `Base.copyto!`.
 """
-function sequence(record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::BioSequences.LongDNASeq
-    return sequence(BioSequences.LongDNASeq, record, part)
+function sequence(record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::BioSequences.LongDNA{4}
+    return sequence(BioSequences.LongDNA{4}, record, part)
 end
 
 """

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -193,7 +193,7 @@ end
 
 Checks whether or not the `record` has a description.
 """
-function hasdescription(record)
+function hasdescription(record::Record)
     return isfilled(record) && record.description != 1:0
 end
 

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -159,7 +159,7 @@ function identifier(record::Record)::Union{String,Nothing}
     if !hasidentifier(record)
         return nothing
     end
-    return String(record.data[record.identifier])
+    return StringView(view(record.data, record.identifier))
 end
 
 """
@@ -185,7 +185,7 @@ function description(record::Record)::Union{String, Nothing}
     if !hasdescription(record)
         nothing
     end
-    return String(record.data[record.description])
+    return StringView(view(record.data, record.description))
 end
 
 """
@@ -211,7 +211,7 @@ function header(record::Record)::Union{String, Nothing}
     id, de = record.identifier, record.description
     isempty(id) && isempty(de) && return nothing
     range = isempty(de) ? id : (isempty(id) ? de : first(id):last(de))
-    return String(record.data[range])
+    return StringView(view(record.data, range))
 end
 
 """

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -147,9 +147,11 @@ end
 # ------------------
 
 """
-    identifier(record::Record)::Union{String,Nothing}
+    identifier(record::Record)::Union{StringView, Nothing}
 
 Get the sequence identifier of `record`.
+Returns an `AbstractString` view into the record. If the record is overwritten,
+the string data will be corrupted.
 
 !!! note
     Returns `nothing` if the record has no identifier.
@@ -173,9 +175,11 @@ end
 
 
 """
-    description(record::Record)::Union{String, Nothing}
+    description(record::Record)::Union{StringView, Nothing}
 
 Get the description of `record`.
+Returns an `AbstractString` view into the record. If the record is overwritten,
+the string data will be corrupted.
 
 !!! note
     Returns `nothing` if `record` has no description.
@@ -203,9 +207,11 @@ function Base.copy!(dest::BioSequences.LongSequence, src::Record)
 end
 
 """
-    header(record::Record)::Union{String, Nothing}
+    header(record::Record)::Union{StringView, Nothing}
 
 Returns the stripped header line of `record`, or `nothing` if it was empty.
+Returns an `AbstractString` view into the record. If the record is overwritten,
+the string data will be corrupted.
 """
 function header(record::Record)::Union{String, Nothing}
     id, de = record.identifier, record.description

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,8 @@ import BioSequences:
     @dna_str,
     @rna_str,
     @aa_str,
-    LongDNASeq,
-    LongAminoAcidSeq,
+    LongDNA,
+    LongAA,
     LongSequence,
     AminoAcidAlphabet,
     DNAAlphabet,
@@ -37,7 +37,7 @@ import BioSequences:
         @test FASTA.hassequence(record)
         @test FASTA.sequence(LongDNASeq, record) == dna"ACGT"
         @test collect(FASTA.sequence_iter(DNA, record)) == [DNA_A, DNA_C, DNA_G, DNA_T] 
-        @test FASTA.sequence(LongDNASeq, record, 2:3) == LongDNASeq(collect(FASTA.sequence_iter(DNA, record, 2:3))) == dna"CG"
+        @test FASTA.sequence(record, 2:3) == LongDNA{4}(collect(FASTA.sequence_iter(DNA, record, 2:3))) == dna"CG"
         @test FASTA.sequence(String, record) == "ACGT"
         @test FASTA.sequence(String, record, 2:3) == "CG"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,9 +35,9 @@ import BioSequences:
         @test FASTA.description(record) === nothing
         @test BioGenerics.hassequence(record)
         @test FASTA.hassequence(record)
-        @test FASTA.sequence(LongDNASeq, record) == dna"ACGT"
+        @test FASTA.sequence(LongDNA{4}, record) == dna"ACGT"
         @test collect(FASTA.sequence_iter(DNA, record)) == [DNA_A, DNA_C, DNA_G, DNA_T] 
-        @test FASTA.sequence(record, 2:3) == LongDNA{4}(collect(FASTA.sequence_iter(DNA, record, 2:3))) == dna"CG"
+        @test FASTA.sequence(LongDNA{4}, record, 2:3) == LongDNA{4}(collect(FASTA.sequence_iter(DNA, record, 2:3))) == dna"CG"
         @test FASTA.sequence(String, record) == "ACGT"
         @test FASTA.sequence(String, record, 2:3) == "CG"
 
@@ -78,8 +78,8 @@ import BioSequences:
         @test FASTA.identifier(record) == "CYS1_DICDI"
         @test FASTA.description(record) == "fragment"
         @test FASTA.header(record) == "CYS1_DICDI fragment"
-        @test FASTA.sequence(LongAminoAcidSeq, record) == aa"SCWSFSTTGNVEGQHFISQNKLVSLSEQNLVDCDHECMEYEGE"
-        @test FASTA.sequence(LongAminoAcidSeq, record, 10:15) == aa"NVEGQH"
+        @test FASTA.sequence(LongAA, record) == aa"SCWSFSTTGNVEGQHFISQNKLVSLSEQNLVDCDHECMEYEGE"
+        @test FASTA.sequence(LongAA, record, 10:15) == aa"NVEGQH"
 
         # PR 37
         s = ">A \nTAG\n"
@@ -113,14 +113,14 @@ import BioSequences:
     @test FASTA.identifier(record) == "seqA"
     @test FASTA.description(record) == "some description"
     @test FASTA.header(record) == "seqA some description"
-    @test FASTA.sequence(LongAminoAcidSeq, record) == aa"QIKDLLVSSSTDLDTTLKMKILELPFASGDLSM"
-    @test copyto!(LongAminoAcidSeq(FASTA.seqlen(record)), record) == aa"QIKDLLVSSSTDLDTTLKMKILELPFASGDLSM"
+    @test FASTA.sequence(LongAA, record) == aa"QIKDLLVSSSTDLDTTLKMKILELPFASGDLSM"
+    @test copyto!(LongAA(undef, FASTA.seqlen(record)), record) == aa"QIKDLLVSSSTDLDTTLKMKILELPFASGDLSM"
     @test read!(reader, record) === record
     @test FASTA.identifier(record) == "seqB"
     @test !FASTA.hasdescription(record)
-    @test FASTA.sequence(LongAminoAcidSeq, record) == aa"VLMALGMTDLFIPSANLTG*"
-    @test copyto!(LongAminoAcidSeq(FASTA.seqlen(record)), record) == aa"VLMALGMTDLFIPSANLTG*"
-    @test_throws ArgumentError copyto!(LongAminoAcidSeq(10), FASTA.Record())
+    @test FASTA.sequence(LongAA, record) == aa"VLMALGMTDLFIPSANLTG*"
+    @test copyto!(LongAA(undef, FASTA.seqlen(record)), record) == aa"VLMALGMTDLFIPSANLTG*"
+    @test_throws ArgumentError copyto!(LongAA(undef, 10), FASTA.Record())
     @test_throws ArgumentError FASTA.extract(reader, AminoAcidAlphabet(), "seqA", 2:3)
 
     function test_fasta_parse(filename, valid)
@@ -218,7 +218,7 @@ import BioSequences:
             open(FASTA.Reader, filepath, index=filepath * ".fai") do reader
                 chr3 = reader["chr3"]
                 @test FASTA.identifier(chr3) == "chr3"
-                @test FASTA.sequence(LongDNASeq, chr3) == dna"""
+                @test FASTA.sequence(LongDNA{4}, chr3) == dna"""
                 AAATAGCCCTCATGTACGTCTCCTCCAAGCCCTGTTGTCTCTTACCCGGA
                 TGTTCAACCAAAAGCTACTTACTACCTTTATTTTATGTTTACTTTTTATA
                 """
@@ -229,7 +229,7 @@ import BioSequences:
 
                 chr2 = reader["chr2"]
                 @test FASTA.identifier(chr2) == "chr2"
-                @test FASTA.sequence(LongDNASeq, chr2) == dna"""
+                @test FASTA.sequence(LongDNA{4}, chr2) == dna"""
                 ATGCATGCATGCAT
                 GCATGCATGCATGC
                 """
@@ -242,7 +242,7 @@ import BioSequences:
 
                 chr1 = reader["chr1"]
                 @test FASTA.identifier(chr1) == "chr1"
-                @test FASTA.sequence(LongDNASeq, chr1) == dna"""
+                @test FASTA.sequence(LongDNA{4}, chr1) == dna"""
                 CCACACCACACCCACACACC
                 """
 
@@ -553,7 +553,7 @@ end
                    +SRR1238088.1.1 HWI-ST499:111:D0G94ACXX:1:1101:1173:2105
                    @BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ
                    """)
-        @test sequence(LongDNASeq, FASTA.Record(fqrecord)) == sequence(fqrecord)
+        @test sequence(LongDNA{4}, FASTA.Record(fqrecord)) == sequence(fqrecord)
         @test identifier(FASTA.Record(fqrecord)) == identifier(fqrecord)
     end
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -344,12 +344,12 @@ end
         @test FASTQ.description(record) == "HWI-ST499:111:D0G94ACXX:1:1101:1173:2105"
         @test FASTQ.header(record) == FASTQ.identifier(record) * " " * FASTA.description(record)
         @test FASTQ.hassequence(record) == BioGenerics.hassequence(record) == true
-        @test FASTQ.sequence(LongDNASeq, record) == seq
-        @test LongDNASeq(collect(FASTQ.sequence_iter(DNA, record))) == seq
-        @test LongDNASeq(collect(FASTQ.sequence_iter(DNA, record, 3:7))) == dna"GCTCA"
-        @test copyto!(LongDNASeq(FASTQ.seqlen(record)), record) == seq
-        @test_throws ArgumentError copyto!(LongDNASeq(10), FASTQ.Record())
-        @test FASTQ.sequence(LongDNASeq, record) == seq
+        @test FASTQ.sequence(LongDNA{4}, record) == seq
+        @test LongDNA{4}(collect(FASTQ.sequence_iter(DNA, record))) == seq
+        @test LongDNA{4}(collect(FASTQ.sequence_iter(DNA, record, 3:7))) == dna"GCTCA"
+        @test copyto!(LongDNA{4}(undef, FASTQ.seqlen(record)), record) == seq
+        @test_throws ArgumentError copyto!(LongDNA{4}(undef, 10), FASTQ.Record())
+        @test FASTQ.sequence(LongDNA{4}, record) == seq
         @test FASTQ.sequence(String, record) == "AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA"
         @test FASTQ.hasquality(record)
         @test FASTQ.quality(record) == b"@BCFFFDFHHHHHJJJIJIJJIJJJJJJJJIJJJJIIIJJJIJJJ" .- 33


### PR DESCRIPTION
Currently, `header`, `identifier` and `description` returns `String`, which forces needless allocations. This PR adds the dependency `StringViews`, which allows the creation of an `AbstractString` from any `AbstractVector{UInt8}`.

The aforementioned functions now return these string views backed by a view into the data buffer.

This change is breaking.