### PR TITLE
Update Julia requirement to 1.6

### DIFF
--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.0' # LTS
+          - '1.6' # LTS
           - '1'
         julia-arch: [x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ BioGenerics = "0.1"
 BioSequences = "2.0.2"
 BioSymbols = "4"
 TranscodingStreams = "0.9.5"
-julia = "1"
+julia = "1.6" # LTS
 
 [extras]
 FormatSpecimens = "3372ea36-2a1a-11e9-3eb7-996970b6ffbd"


### PR DESCRIPTION
Since 1.6 is the oldest currently supported version of Julia, we might as well do this.