### PR TITLE
Bump BioSequences/BioSymbols to v3/v5

### DIFF
--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.0' # LTS
+          - '1.6' # LTS
           - '1'
         julia-arch: [x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = [
     "Sabrina J. Ward <sabrinajward@protonmail.com>",
     "Jakob N. Nissen <jakobnybonissen@gmail.com>"
 ]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
@@ -16,8 +16,8 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [compat]
 Automa = "0.7, 0.8"
 BioGenerics = "0.1"
-BioSequences = "2.0.2"
-BioSymbols = "4"
+BioSequences = "3"
+BioSymbols = "5"
 TranscodingStreams = "0.9.5"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ BioGenerics = "0.1"
 BioSequences = "3"
 BioSymbols = "5"
 TranscodingStreams = "0.9.5"
-julia = "1"
+julia = "1.6"
 
 [extras]
 FormatSpecimens = "3372ea36-2a1a-11e9-3eb7-996970b6ffbd"

--- a/src/fasta/record.jl
+++ b/src/fasta/record.jl
@@ -243,7 +243,7 @@ If `part` argument is given, it returns the specified part of the sequence.
 function sequence(::Type{S}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::S where S <: BioSequences.LongSequence
     checkfilled(record)
     seqpart = record.sequence[part]
-    return S(record.data, first(seqpart), last(seqpart))
+    return S(@view(record.data[seqpart]))
 end
 
 function sequence(::Type{String}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::String
@@ -367,12 +367,12 @@ function predict_seqtype(seq::Vector{UInt8}, range)
     # the threshold (= 0.95) is somewhat arbitrary
     if (a + c + g + t + u + n) / alpha > 0.95
         if t ≥ u
-            return BioSequences.LongDNASeq
+            return BioSequences.LongDNA{4}
         else
-            return BioSequences.LongRNASeq
+            return BioSequences.LongRNA{4}
         end
     else
-        return BioSequences.LongAminoAcidSeq
+        return BioSequences.LongAA
     end
 end
 

--- a/src/fastq/record.jl
+++ b/src/fastq/record.jl
@@ -271,7 +271,7 @@ If `part` argument is given, it returns the specified part of the sequence.
 function sequence(::Type{S}, record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::S where S <: BioSequences.LongSequence
     checkfilled(record)
     seqpart = record.sequence[part]
-    return S(record.data, first(seqpart), last(seqpart))
+    return S(@view(record.data[seqpart]))
 end
 
 """
@@ -295,8 +295,8 @@ Get the sequence of `record`.
     If you have a sequence already and want to fill it with the sequence
     data contained in a fastq record, you can use `Base.copyto!`.
 """
-function sequence(record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::BioSequences.LongDNASeq
-    return sequence(BioSequences.LongDNASeq, record, part)
+function sequence(record::Record, part::UnitRange{Int}=1:lastindex(record.sequence))::BioSequences.LongDNA{4}
+    return sequence(BioSequences.LongDNA{4}, record, part)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,8 @@ import BioSequences:
     @dna_str,
     @rna_str,
     @aa_str,
-    LongDNASeq,
-    LongAminoAcidSeq,
+    LongDNA,
+    LongAA,
     LongSequence,
     AminoAcidAlphabet,
     DNAAlphabet,
@@ -37,7 +37,7 @@ import BioSequences:
         @test FASTA.hassequence(record)
         @test FASTA.sequence(record) == dna"ACGT"
         @test collect(FASTA.sequence_iter(DNA, record)) == [DNA_A, DNA_C, DNA_G, DNA_T] 
-        @test FASTA.sequence(record, 2:3) == LongDNASeq(collect(FASTA.sequence_iter(DNA, record, 2:3))) == dna"CG"
+        @test FASTA.sequence(record, 2:3) == LongDNA{4}(collect(FASTA.sequence_iter(DNA, record, 2:3))) == dna"CG"
         @test FASTA.sequence(String, record) == "ACGT"
         @test FASTA.sequence(String, record, 2:3) == "CG"
 
@@ -112,13 +112,13 @@ import BioSequences:
     @test FASTA.description(record) == "some description"
     @test FASTA.header(record) == "seqA some description"
     @test FASTA.sequence(record) == aa"QIKDLLVSSSTDLDTTLKMKILELPFASGDLSM"
-    @test copyto!(LongAminoAcidSeq(FASTA.seqlen(record)), record) == aa"QIKDLLVSSSTDLDTTLKMKILELPFASGDLSM"
+    @test copyto!(LongAA(undef, FASTA.seqlen(record)), record) == aa"QIKDLLVSSSTDLDTTLKMKILELPFASGDLSM"
     @test read!(reader, record) === record
     @test FASTA.identifier(record) == "seqB"
     @test !FASTA.hasdescription(record)
     @test FASTA.sequence(record) == aa"VLMALGMTDLFIPSANLTG*"
-    @test copyto!(LongAminoAcidSeq(FASTA.seqlen(record)), record) == aa"VLMALGMTDLFIPSANLTG*"
-    @test_throws ArgumentError copyto!(LongAminoAcidSeq(10), FASTA.Record())
+    @test copyto!(LongAA(undef, FASTA.seqlen(record)), record) == aa"VLMALGMTDLFIPSANLTG*"
+    @test_throws ArgumentError copyto!(LongAA(undef, 10), FASTA.Record())
     @test_throws ArgumentError FASTA.extract(reader, AminoAcidAlphabet(), "seqA", 2:3)
 
     function test_fasta_parse(filename, valid)
@@ -342,11 +342,11 @@ end
         @test FASTQ.description(record) == "HWI-ST499:111:D0G94ACXX:1:1101:1173:2105"
         @test FASTQ.header(record) == FASTQ.identifier(record) * " " * FASTA.description(record)
         @test FASTQ.hassequence(record) == BioGenerics.hassequence(record) == true
-        @test FASTQ.sequence(LongDNASeq, record) == seq
-        @test LongDNASeq(collect(FASTQ.sequence_iter(DNA, record))) == seq
-        @test LongDNASeq(collect(FASTQ.sequence_iter(DNA, record, 3:7))) == dna"GCTCA"
-        @test copyto!(LongDNASeq(FASTQ.seqlen(record)), record) == seq
-        @test_throws ArgumentError copyto!(LongDNASeq(10), FASTQ.Record())
+        @test FASTQ.sequence(LongDNA{4}, record) == seq
+        @test LongDNA{4}(collect(FASTQ.sequence_iter(DNA, record))) == seq
+        @test LongDNA{4}(collect(FASTQ.sequence_iter(DNA, record, 3:7))) == dna"GCTCA"
+        @test copyto!(LongDNA{4}(undef, FASTQ.seqlen(record)), record) == seq
+        @test_throws ArgumentError copyto!(LongDNA{4}(undef, 10), FASTQ.Record())
         @test FASTQ.sequence(record) == BioGenerics.sequence(record) == seq
         @test FASTQ.sequence(String, record) == "AAGCTCATGACCCGTCTTACCTACACCCTTGACGAGATCGAAGGA"
         @test FASTQ.hasquality(record)


### PR DESCRIPTION
This creates a new version of FASTX using the latest BioSequences/BioSymbols. It contains no breaking changes.

I think FASTX could use a more thorough release where e.g. the tests are fixed up. But that's a larger undertaking, this is just to allow BioSequences v3 to be used with FASTX.