### PR TITLE
Clarify that streams take ownership of IO

### DIFF
--- a/docs/src/manual/fasta.md
+++ b/docs/src/manual/fasta.md
@@ -41,6 +41,11 @@ w = FASTA.Writer(open("my-out.fasta", "w"))
 
 As always with julia IO types, remember to close your file readers and writer
 after you are finished.
+In particular, `Reader` and `Writer` objects take _ownership_ of the underlying IO.
+This means that you should not modify or use the underlying IO while a reader or
+writer is using it.
+When you are done with the reader/writer, close it and not the underlying IO.
+The underlying IO will automatically be closed when closing the reader/writer.
 
 Using `open` with a do-block can help ensure you close a stream after you are
 finished. `Base.open` is overloaded with a method for this purpose.

--- a/docs/src/manual/fastq.md
+++ b/docs/src/manual/fastq.md
@@ -43,6 +43,11 @@ w = FASTQ.Writer(open("my-output.fastq", "w"))
 
 As always with julia IO types, remember to close your file readers and writer
 after you are finished.
+In particular, `Reader` and `Writer` objects take _ownership_ of the underlying IO.
+This means that you should not modify or use the underlying IO while a reader or
+writer is using it.
+When you are done with the reader/writer, close it and not the underlying IO.
+The underlying IO will automatically be closed when closing the reader/writer.
 
 Using `open` with a do-block can help ensure you close a stream after you are
 finished. `Base.open` is overloaded with a method for this purpose.

--- a/src/fasta/reader.jl
+++ b/src/fasta/reader.jl
@@ -14,6 +14,22 @@ Create a data reader of the FASTA file format.
 # Arguments
 * `input`: data source
 * `index=nothing`: filepath to a random access index (currently *fai* is supported)
+
+# Extended help
+`Reader`s take ownership of the underlying IO. That means the underlying IO may
+not be directly modified such as writing or reading from it, or seeking in it.
+
+`Reader`s carry their own buffer. This buffer is flushed when the `Reader` is closed.
+Do not close the underlying IO without flushing the `Reader` first. Closing the
+`Reader` automatically flushes, then closes the underlying IO, and is preferred.
+
+`Reader`s are iterable and yield `Record` objects. For improved reading speed,
+instantiate a single `Record`, then `read!` into the record repeatedly until 
+`eof(reader)`. Note that this approach overwrite the same mutable `Record`.
+
+* iterate
+* close
+
 """
 function Reader(input::IO; index = nothing)
     if isa(index, AbstractString)

--- a/src/fasta/reader.jl
+++ b/src/fasta/reader.jl
@@ -19,17 +19,13 @@ Create a data reader of the FASTA file format.
 `Reader`s take ownership of the underlying IO. That means the underlying IO may
 not be directly modified such as writing or reading from it, or seeking in it.
 
-`Reader`s carry their own buffer. This buffer is flushed when the `Reader` is closed.
-Do not close the underlying IO without flushing the `Reader` first. Closing the
-`Reader` automatically flushes, then closes the underlying IO, and is preferred.
+`Reader`s carry their own buffer. This means that the underlying IO may be `eof`
+before the `Reader` itself. To avoid issues, do not interact with the underlying
+IO while a `Reader` is using it.
 
 `Reader`s are iterable and yield `Record` objects. For improved reading speed,
 instantiate a single `Record`, then `read!` into the record repeatedly until 
 `eof(reader)`. Note that this approach overwrite the same mutable `Record`.
-
-* iterate
-* close
-
 """
 function Reader(input::IO; index = nothing)
     if isa(index, AbstractString)

--- a/src/fasta/writer.jl
+++ b/src/fasta/writer.jl
@@ -9,6 +9,14 @@ Create a data writer of the FASTA file format.
 # Arguments
 * `output`: data sink
 * `width=70`: wrapping width of sequence characters
+
+# Extended help
+`Writer`s take ownership of the underlying IO. That means the underlying IO may
+not be directly modified such as writing or reading from it, or seeking in it.
+
+`Writer`s carry their own buffer. This buffer is flushed when the `Writer` is closed.
+Do not close the underlying IO without flushing the `Writer` first. Closing the
+`Writer` automatically flushes, then closes the underlying IO, and is preferred.
 """
 struct Writer{S <: TranscodingStream} <: BioGenerics.IO.AbstractWriter
     output::S

--- a/src/fastq/reader.jl
+++ b/src/fastq/reader.jl
@@ -14,6 +14,18 @@ Create a data reader of the FASTQ file format.
 # Arguments
 * `input`: data source
 * `fill_ambiguous=nothing`: fill ambiguous symbols with the given symbol
+
+# Extended help
+`Reader`s take ownership of the underlying IO. That means the underlying IO may
+not be directly modified such as writing or reading from it, or seeking in it.
+
+`Reader`s carry their own buffer. This means that the underlying IO may be `eof`
+before the `Reader` itself. To avoid issues, do not interact with the underlying
+IO while a `Reader` is using it.
+
+`Reader`s are iterable and yield `Record` objects. For improved reading speed,
+instantiate a single `Record`, then `read!` into the record repeatedly until 
+`eof(reader)`. Note that this approach overwrite the same mutable `Record`.
 """
 function Reader(input::IO; fill_ambiguous = nothing)
     if fill_ambiguous === nothing

--- a/src/fastq/writer.jl
+++ b/src/fastq/writer.jl
@@ -19,6 +19,14 @@ Create a data writer of the FASTQ file format.
 # Arguments
 * `output`: data sink
 * `quality_header=false`: output the title line at the third line just after '+'
+
+# Extended help
+`Writer`s take ownership of the underlying IO. That means the underlying IO may
+not be directly modified such as writing or reading from it, or seeking in it.
+
+`Writer`s carry their own buffer. This buffer is flushed when the `Writer` is closed.
+Do not close the underlying IO without flushing the `Writer` first. Closing the
+`Writer` automatically flushes, then closes the underlying IO, and is preferred.
 """
 function Writer(output::IO, quality_header::Bool)
     if output isa TranscodingStream


### PR DESCRIPTION
Simple documentation change. Should also be ported to v2.