### PR TITLE
Fix missing character in docs example

### DIFF
--- a/docs/src/manual/fasta.md
+++ b/docs/src/manual/fasta.md
@@ -113,7 +113,7 @@ To write a `BioSequence` to FASTA file, you first have to create a [`FASTA.Recor
 using BioSequences
 x = dna"aaaaatttttcccccggggg"
 rec = FASTA.Record("MySeq", x)
-open(FASTA.Writer, "my-out.fasta") do
+open(FASTA.Writer, "my-out.fasta") do w
     write(w, rec)
 end
 ```


### PR DESCRIPTION
Fix single char typo in docs.