### PR TITLE
[RFC]: Broaden characters allowed in FASTA sequences

### DIFF
--- a/docs/src/manual/fasta.md
+++ b/docs/src/manual/fasta.md
@@ -113,7 +113,7 @@ To write a `BioSequence` to FASTA file, you first have to create a [`FASTA.Recor
 using BioSequences
 x = dna"aaaaatttttcccccggggg"
 rec = FASTA.Record("MySeq", x)
-open(FASTA.Writer, "my-out.fasta") do
+open(FASTA.Writer, "my-out.fasta") do w
     write(w, rec)
 end
 ```

--- a/src/fasta/readrecord.jl
+++ b/src/fasta/readrecord.jl
@@ -20,8 +20,8 @@ machine = (function ()
     header.actions[:enter] = [:mark]
     header.actions[:exit]  = [:header]
     
-    # '*': terminal, `-': gap
-    letters = re"[A-Za-z*\-]+"
+    letters = re.rep1(re"[!-~]" \ re">")
+    
     letters.actions[:enter] = [:mark]
     letters.actions[:exit]  = [:letters]
     


### PR DESCRIPTION
This PR allows all printable ASCII characters in FASTA sequences. That is, all bytes represented by the characters `'!':'~'`  but not `>`. Like before, horizontal whitespace, i.e. `\t\v` and space is allowed inside sequences, but are not considered part of the sequence.

I think this character set is the broadest possible set that is practically parseable. Expanding it further would mean allowing non-printable characters, which would be a complete mess, or Unicode, which would be another complete mess.

This PR is meant just to toss the idea out there, for debate. I have no strong intuition it is actually a good idea.