### PR TITLE
Add SnoopPrecompile

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
 BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 ScanByte = "7b38b023-a4d7-4c5e-8d43-3f3097f304eb"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
@@ -19,6 +20,7 @@ ScanByte = "0.3"
 StringViews = "1"
 TranscodingStreams = "0.9.5"
 julia = "1.6"
+SnoopPrecompile = "1"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -1,7 +1,7 @@
 module FASTX
 
 using StringViews: StringView
-using BioSequences: BioSequence, LongSequence
+using BioSequences: BioSequences, BioSequence, LongSequence
 using Automa: Automa
 
 """
@@ -255,6 +255,8 @@ const FASTAReader = FASTA.Reader
 const FASTQReader = FASTQ.Reader
 const FASTAWriter = FASTA.Writer
 const FASTQWriter = FASTQ.Writer
+
+include("workload.jl")
 
 export
     FASTA,

--- a/src/workload.jl
+++ b/src/workload.jl
@@ -1,0 +1,35 @@
+using SnoopPrecompile
+
+@precompile_all_calls begin
+    fasta = ">abc def\nTAG\nTA"
+    fastq = "@ABC DEF\nTAGC\n+ABC DEF\nJJJJ"
+    records = [
+        parse(FASTA.Record, fasta),
+        parse(FASTQ.Record, fastq)
+    ]
+    for record in records
+        identifier(record)
+        description(record)
+        seqsize(record)
+        sequence(record)
+        sequence(BioSequences.LongDNA{2}, record)
+        sequence(BioSequences.LongDNA{4}, record)
+        sequence(BioSequences.LongAA, record)
+    end
+
+    # FASTQ specific
+    record = last(records)
+    quality(record)
+    collect(quality_scores(record))
+
+    validate_fasta(IOBuffer(fasta))
+    validate_fastq(IOBuffer(fastq))
+
+    collect(FASTAReader(IOBuffer(fasta)))
+    collect(FASTQReader(IOBuffer(fastq)))
+
+    ind = faidx(IOBuffer(fasta))
+    rdr = FASTAReader(IOBuffer(fasta); index=ind)
+    extract(rdr, "abc", 2:3)
+    seekrecord(rdr, "abc")
+end


### PR DESCRIPTION
The small dependency SnoopPrecompile allows more efficient precompile statements
in packages. Hence, this change somewhat reduces latency of FASTX.jl, and is
expected to cause even larger latency reductions when Julia's compiler improves