### PR TITLE
Improve precompilation

### DIFF
--- a/test/test.fasta
+++ b/test/test.fasta
@@ -1,0 +1,3 @@
+>abc def
+TAG
+TA

--- a/test/test.fastq
+++ b/test/test.fastq
@@ -1,0 +1,4 @@
+@ABC DEF
+TAGC
++ABC DEF
+JJJJ


### PR DESCRIPTION
Improve precompilation by operating on files instead of IOBuffers. This is more representative of a realistic workload.
