### PR TITLE
Fix Base.read!(::Reader, ::Record) and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1]
+### Bugfix
+* Fix `Base.read!(::FASTQReader, ::FASTQRecord)` (issue #95)
+
 ## [2.0.0]
 Version 2 is a near-complete rewrite of FASTX.
 It brings strives to provide an easier and more consistent API, while also being

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FASTX"
 uuid = "c2308a5c-f048-11e8-3e8a-31650f418d12"
 authors = ["Sabrina J. Ward <sabrinajward@protonmail.com>", "Jakob N. Nissen <jakobnybonissen@gmail.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [weakdeps]
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"

--- a/src/fastq/reader.jl
+++ b/src/fastq/reader.jl
@@ -67,7 +67,7 @@ function Base.iterate(rdr::Reader, state=nothing)
 end
 
 function Base.read!(rdr::Reader, rec::Record)
-    (cs, f) = _read!(rdr, rdr.record)
+    (cs, f) = _read!(rdr, rec)
     if !f
         cs == 0 && throw(EOFError())
         throw(ArgumentError("malformed FASTQ file"))

--- a/test/fasta/io.jl
+++ b/test/fasta/io.jl
@@ -27,6 +27,16 @@
     @test records[1] != records[3]
     close(reader)
 
+    # Test Base.read! works
+    reader = Reader(IOBuffer(">header string\r\nYWBL\nKKL\r\n>another\nAAGTC"))
+    record = Record()
+    read!(reader, record)
+    @test identifier(record) == "header"
+    @test description(record) == "header string"
+    @test sequence(record) == "YWBLKKL"
+    (record, _) = iterate(reader)
+    @test (description(record), sequence(record)) == ("another", "AAGTC")
+
     # Does not copy on iteration if copy=false
     # in this case it will iterate the same object which
     # will just be overwritten.

--- a/test/fastq/io.jl
+++ b/test/fastq/io.jl
@@ -29,6 +29,17 @@
     @test records[1] != records[3]
     close(reader)
 
+    # Test Base.read! works
+    reader = Reader(IOBuffer("@HWI:HDR TEXT\nTAGGCTAG\n+\nKM@BCAAC\n@A\nTAG\n+\nJJK\n"))
+    record = Record()
+    read!(reader, record)
+    @test identifier(record) == "HWI:HDR"
+    @test description(record) == "HWI:HDR TEXT"
+    @test sequence(record) == "TAGGCTAG"
+    @test quality(record) == "KM@BCAAC"
+    (record, _) = iterate(reader)
+    @test (description(record), sequence(record), quality(record)) == ("A", "TAG", "JJK")
+
     # Does not copy on iteration if copy=false
     # See comments in equivalent FASTA tests
     reader = Reader(IOBuffer(copy_str); copy=false)


### PR DESCRIPTION
These functions were not tested directly, and indeed did not work for FASTQ, due to a typo.

Closes #95 