### PR TITLE
Add Base.print(::IO, ::Index)

### DIFF
--- a/src/fasta/index.jl
+++ b/src/fasta/index.jl
@@ -209,6 +209,12 @@ function Base.write(io::IO, index::Index)
     n
 end
 
+function Base.print(io::IO, index::Index)
+    buffer = IOBuffer()
+    write(buffer, index)
+    String(take!(buffer))
+end
+
 index_fasta_actions = Dict(
     :mark => :(@mark),
     :countline => :(linenum += 1),

--- a/test/fasta/index.jl
+++ b/test/fasta/index.jl
@@ -24,6 +24,7 @@ function test_same_index(a::Index, b::Index)
     @test a.lengths == b.lengths
     @test a.offsets == b.offsets
     @test a.encoded_linebases == b.encoded_linebases
+    @test string(a) == string(b)
 end
 
 @testset "Parsing index" begin


### PR DESCRIPTION
This allows the user to turn an `Index` into a string easily, and also makes it easier to test the indices.