### PR TITLE
Disable CI for x86 macOS-latest

### DIFF
--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -15,13 +15,16 @@ jobs:
           - '1.6' # LTS
           - '1'
         julia-arch: [x86]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
         experimental: [false]
         include:
           - julia-version: nightly
             julia-arch: x86
             os: ubuntu-latest
             experimental: true
+          - julia-version: 1
+            os: macOS-latest
+            experimental: false
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This combination no longer exists, since the latests versions of MacOS does not run on x86 processors anymore.
