### PR TITLE
Upgrade CI

### DIFF
--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -12,33 +12,43 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.6' # LTS
           - '1'
-        julia-arch: [x86]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         experimental: [false]
         include:
+          # Include nightly, but experimental, so it's allowed to fail without
+          # failing CI.
           - julia-version: nightly
-            julia-arch: x86
             os: ubuntu-latest
             experimental: true
-          - julia-version: 1
+            fail_ci_if_error: false
+          # Windows is extremely slow on 1.6, so we skip this combination,
+          # since it increases CI time by 5x
+          - julia-version: '1.7'
+            os: windows-latest
+            experimental: false
+          # Oldest supported version
+          - julia-version: '1.6'
+            os: ubuntu-latest
+            experimental: false
+          # MacOS Aarch64 reached Tier1 support of Julia in version 1.9
+          - julia-version: '1.9'
             os: macOS-latest
             experimental: false
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
       - name: Run Tests
         uses: julia-actions/julia-runtest@latest
       - name: Create CodeCov
-        uses: julia-actions/julia-processcoverage@v1
+        uses: julia-actions/julia-processcoverage@latest
       - name: Upload CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           file: ./lcov.info
           flags: unittests


### PR DESCRIPTION
* Run Windows on 1.7, not LTS, to avoid slow registry cloning and speed up CI severalfold
* Run MacOS on 1.9 also, the first version with MacOS ARM tier 1 support
* Do not specify architechture
* Upgrade to the newer versions of actions