### PR TITLE
Drop support for Julia <1.10

### DIFF
--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -11,8 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version:
-          - '1'
+        julia-version: ['1', '1.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         experimental: [false]
         include:
@@ -22,19 +21,6 @@ jobs:
             os: ubuntu-latest
             experimental: true
             fail_ci_if_error: false
-          # Windows is extremely slow on 1.6, so we skip this combination,
-          # since it increases CI time by 5x
-          - julia-version: '1.7'
-            os: windows-latest
-            experimental: false
-          # Oldest supported version
-          - julia-version: '1.6'
-            os: ubuntu-latest
-            experimental: false
-          # MacOS Aarch64 reached Tier1 support of Julia in version 1.9
-          - julia-version: '1.9'
-            os: macOS-latest
-            experimental: false
 
     steps:
       - name: Checkout Repository

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ BioSequences = "3"
 PrecompileTools = "1"
 StringViews = "1"
 TranscodingStreams = "0.9.5, 0.10, 0.11"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
Now that Julia 1.10 is LTS, we can drop support for older versions.
In preparation for an upcoming PR that makes use of `const` fields - a 1.8 feature.
Also, this allows us to simplify the CI.