### PR TITLE
Delete workaround for compat with extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
 BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"
-BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"

--- a/src/FASTX.jl
+++ b/src/FASTX.jl
@@ -220,10 +220,6 @@ const FASTQReader = FASTQ.Reader
 const FASTAWriter = FASTA.Writer
 const FASTQWriter = FASTQ.Writer
 
-if !isdefined(Base, :get_extension)
-    include("../ext/BioSequencesExt.jl")
-  end
-
 include("workload.jl")
 
 export


### PR DESCRIPTION
To allow the BioSequences FASTX extension to be supported with Julia <1.9, a few hacks had to be done.
Remove these hacks, as we now longer support these versions.

