### PR TITLE
support StringViews 2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Automa = "1"
 BioGenerics = "0.1.2"
 BioSequences = "3"
 PrecompileTools = "1"
-StringViews = "1"
+StringViews = "1, 2"
 TranscodingStreams = "0.9.5, 0.10, 0.11"
 julia = "1.10"
 


### PR DESCRIPTION
Updates the package to use StringViews 2.0 if available (which has minor breaking changes with 1.0 that shouldn't affect this package).  In Julia 1.14, where the StringView type is merged into Base, the StringViews 2.0 package becomes a simple stub around the Base type.
